### PR TITLE
Window title changed

### DIFF
--- a/src/logindialog.cpp
+++ b/src/logindialog.cpp
@@ -227,6 +227,7 @@ void LoginDialog::OnMainPageFinished() {
     std::string league(ui->leagueComboBox->currentText().toStdString());
     app_->InitLogin(login_manager_, league, account.toStdString());
     mw = new MainWindow(app_);
+    mw->setWindowTitle(QString("Acquisition - %1").arg(league.c_str()));
     mw->show();
     close();
 }


### PR DESCRIPTION
Instead of having the Acquisition window title always be "Acquisition", it now changes depending on which league you've selected.
Example to see format: "Acquisition - Beyond"
This is useful when running multiple Acquisition clients for each league you have a shop in.
