### PR TITLE
Add an option to use the system proxy settings.

### DIFF
--- a/forms/logindialog.ui
+++ b/forms/logindialog.ui
@@ -133,7 +133,7 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="errorLabel">
        <property name="text">
         <string>TextLabel</string>
@@ -164,6 +164,13 @@
       <widget class="QCheckBox" name="rembmeCheckBox">
        <property name="text">
         <string>Remember me</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="proxyCheckBox">
+       <property name="text">
+        <string>Use system proxy</string>
        </property>
       </widget>
      </item>

--- a/src/logindialog.h
+++ b/src/logindialog.h
@@ -49,6 +49,7 @@ public slots:
     void OnLoginPageFinished();
     void OnLoggedIn();
     void OnMainPageFinished();
+    void OnProxyCheckBoxClicked(bool);
     void OnSteamCookieReceived(const QString &cookie);
     void OnSteamDialogClosed();
 protected:


### PR DESCRIPTION
### details

* Add a checkbox in the login dialog to let the user decides if he wants to use
the system proxy settings.
* Add a setting field "use_system_proxy_checked" to remember the user choice.

### debt+
Upon check, the application should reload the leagues, but the league loading
system seems broken anyway.