### PR TITLE
Fixes login issue relating to steam.

### DIFF
--- a/src/steamlogindialog.h
+++ b/src/steamlogindialog.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QNetworkCookie>
 
 namespace Ui {
 class SteamLoginDialog;
@@ -41,6 +42,9 @@ protected:
 private:
     Ui::SteamLoginDialog *ui;
     bool completed_;
+    void SetSteamCookie(QNetworkCookie);
+    void SaveSteamCookie(QNetworkCookie);
+    QNetworkCookie LoadSteamCookie();
 private slots:
     void OnLoadFinished();
 };

--- a/src/steamlogindialog.h
+++ b/src/steamlogindialog.h
@@ -45,6 +45,8 @@ private:
     void SetSteamCookie(QNetworkCookie);
     void SaveSteamCookie(QNetworkCookie);
     QNetworkCookie LoadSteamCookie();
+
+    std::string settings_path_;
 private slots:
     void OnLoadFinished();
 };


### PR DESCRIPTION
Fixes xyzz/acquisition#35

Introduces three new methods:
SetSteamCookie, SaveSteamCookie, and LoadSteamCookie which do as they
say. Moreover, it adds additional logic to "OnLoadFinished" which aids in
ensuring this bug doesn't persist.

I'm pretty new to QT, so if it's not up to standards, I'm more than willing to fix it.