### PR TITLE
Correctly draw items from special character slots. ( issue#22 )

### DIFF
--- a/src/itemconstants.h
+++ b/src/itemconstants.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <map>
+
 const int PIXELS_PER_SLOT = 47;
 const int INVENTORY_SLOTS = 12;
 
@@ -27,3 +29,14 @@ const int MAX_EXPANDABLE_ITEMS = 1000;
 
 const int PIXELS_PER_MINIMAP_SLOT = 10;
 const int MINIMAP_SIZE = INVENTORY_SLOTS * PIXELS_PER_MINIMAP_SLOT;
+
+struct position {
+    double x;
+    double y;
+};
+
+std::map<std::string, position> const POS_MAP{
+    {"MainInventory", {0, 7}}, {"BodyArmour", {5, 2}}, {"Weapon", {2, 0}}, {"Weapon2", {2, 0}}, {"Offhand", {8, 0}},
+    {"Offhand2", {8, 0}}, {"Boots", {7, 4}}, {"Ring", {4, 3}}, {"Ring2", {7, 3}}, {"Amulet", {7, 2}},
+    {"Gloves", {3, 4}}, {"Belt", {5, 5}}, {"Helm", {5, 0}}, {"Flask", {3.5, 6}}
+};

--- a/src/itemlocation.cpp
+++ b/src/itemlocation.cpp
@@ -78,8 +78,24 @@ std::string ItemLocation::GetHeader() const {
 
 QRectF ItemLocation::GetRect() const {
     QRectF result;
-    result.setX(MINIMAP_SIZE * x_ / INVENTORY_SLOTS);
-    result.setY(MINIMAP_SIZE * y_ / INVENTORY_SLOTS);
+    position itemPos;
+    itemPos.x = x_;
+    itemPos.y = y_;
+
+    if ((!inventory_id_.empty()) && (type_ == ItemLocationType::CHARACTER)) {
+        if (inventory_id_ == "MainInventory") {
+            itemPos.y += POS_MAP.at(inventory_id_).y;
+        } else if (inventory_id_ == "Flask") {
+            itemPos.x += POS_MAP.at(inventory_id_).x;
+            itemPos.y = POS_MAP.at(inventory_id_).y;
+        }
+        else {
+            itemPos = POS_MAP.at(inventory_id_);
+        }
+    }
+
+    result.setX(MINIMAP_SIZE * itemPos.x / INVENTORY_SLOTS);
+    result.setY(MINIMAP_SIZE * itemPos.y / INVENTORY_SLOTS);
     result.setWidth(MINIMAP_SIZE * w_ / INVENTORY_SLOTS);
     result.setHeight(MINIMAP_SIZE * h_ / INVENTORY_SLOTS);
     return result;


### PR DESCRIPTION
This solves the drawing problem of character items on the minimap. However, the gems equipped in these items are displayed on the upper left corner. An other issue could be opened for this problem.
