### PR TITLE
Update to CurrencyManager

### DIFF
--- a/src/currencymanager.cpp
+++ b/src/currencymanager.cpp
@@ -247,6 +247,7 @@ void CurrencyManager::ParseSingleItem(const Item &item) {
 void CurrencyManager::DisplayCurrency() {
 
     dialog_->show();
+    dialog_->UpdateVisual();
 }
 
 
@@ -330,7 +331,8 @@ void CurrencyDialog::Update() {
     }
     UpdateTotalValue();
     UpdateTotalWisdomValue();
-    UpdateVisual();
+    if(isVisible())
+        UpdateVisual();
 
 
 }

--- a/src/currencymanager.cpp
+++ b/src/currencymanager.cpp
@@ -30,19 +30,32 @@
 #include "item.h"
 #include "porting.h"
 #include "util.h"
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/error/en.h"
+#include "rapidjson_util.h"
+
 
 CurrencyManager::CurrencyManager(Application &app):
     app_(app),
     data_(app.data())
 {
-    if (data_.Get("currency_base", "").empty())
+    if (data_.Get("currency_items", "").empty()) {
+
+        FirstInitCurrency();
+        if (!data_.Get("currency_base", "").empty()) {
+            MigrateCurrency();
+            QLOG_INFO() << "Found old currency values, migrated them to the new system";
+        }
+    }
+    else
         InitCurrency();
-    LoadCurrency();
-    dialog_ = std::make_unique<CurrencyDialog>(*this);
+
+    dialog_ = std::make_shared<CurrencyDialog>(*this);
 }
 
 CurrencyManager::~CurrencyManager() {
-    SaveCurrencyBase();
+    SaveCurrencyItems();
 }
 
 void CurrencyManager::Update() {
@@ -50,30 +63,25 @@ void CurrencyManager::Update() {
     for (auto &item : app_.items_manager().items()) {
         ParseSingleItem(*item);
     }
-    UpdateExaltedValue();
     SaveCurrencyValue();
     dialog_->Update();
 }
 
-void CurrencyManager::UpdateBaseValue(int ind, double value) {
-    currencies_[ind].base = value;
-}
-
 const double EPS = 1e-6;
-
-void CurrencyManager::UpdateExaltedValue() {
-    for (auto &currency : currencies_) {
-        if (fabs(currency.base) > EPS)
-            currency.exalt = currency.count / currency.base;
-        else
-            currency.exalt = 0;
-    }
-}
-
 double CurrencyManager::TotalExaltedValue() {
     double out = 0;
     for (const auto &currency : currencies_) {
-        out += currency.exalt;
+        if (fabs(currency->exalt.value1) > EPS)
+            out += currency->count / currency->exalt.value1;
+    }
+    return out;
+}
+
+double CurrencyManager::TotalChaosValue() {
+    double out = 0;
+    for (const auto &currency : currencies_) {
+        if (fabs(currency->chaos.value1) > EPS)
+            out += currency->count / currency->chaos.value1;
     }
     return out;
 }
@@ -88,47 +96,83 @@ int CurrencyManager::TotalWisdomValue() {
 
 void CurrencyManager::ClearCurrency() {
     for (auto& currency : currencies_) {
-        currency.count = 0;
+        currency->count = 0;
     }
     for (auto& wisdom : wisdoms_) {
         wisdom = 0;
     }
 }
-
 void CurrencyManager::InitCurrency() {
-    std::string value = "";
-    for (auto curr : CurrencyAsString) {
-        value += "0;";
-    }
-    value.pop_back(); // Remove the last ";"
-    data_.Set("currency_base", value);
-    data_.Set("currency_last_value", value);
-}
-
-void CurrencyManager::LoadCurrency() {
-    std::vector<std::string> list = Util::StringSplit(data_.Get("currency_base"), ';');
-    for (unsigned int i = 0; i < list.size(); i++) {
-        CurrencyItem curr;
-        curr.count = 0;
-        curr.name = CurrencyAsString[i];
-        // We can't use the toDouble function from QT, because it encodes a double with a ","
-        // Might be related to localisation issue, but anyway it's safer this way
-        curr.base = std::stod(list[i]);
-        curr.exalt = 0;
-        currencies_.push_back(curr);
-    }
+    Deserialize(data_.Get("currency_items"), &currencies_);
     for (unsigned int i = 0; i < CurrencyWisdomValue.size(); i++) {
         wisdoms_.push_back(0);
     }
 }
 
-void CurrencyManager::SaveCurrencyBase() {
+void CurrencyManager::FirstInitCurrency() {
     std::string value = "";
-    for (auto currency : currencies_) {
-        value += std::to_string(currency.base) + ";";
+    //Dummy items + dummy currency_last_value
+    //TODO : can i get the size of the Currency enum ??
+    for(unsigned int i = 0; i < CurrencyAsString.size();i++) {
+        currencies_.push_back(std::make_shared<CurrencyItem>(0, static_cast<Currency>(i), 1, 1));
+
+        value += "0;";
     }
     value.pop_back(); // Remove the last ";"
-    data_.Set("currency_base", value);
+    data_.Set("currency_items", Serialize(currencies_));
+    data_.Set("currency_last_value", value);
+}
+
+void CurrencyManager::MigrateCurrency() {
+    std::vector<std::string> list = Util::StringSplit(data_.Get("currency_base"), ';');
+        for (unsigned int i = 0; i < list.size(); i++) {
+            // We can't use the toDouble function from QT, because it encodes a double with a ","
+            // Might be related to localisation issue, but anyway it's safer this way
+            currencies_[i]->exalt.value1 = std::stod(list[i]);
+        }
+    //Set to empty so we won't trigger it next time !
+    data_.Set("currency_base", "");
+}
+
+std::string CurrencyManager::Serialize(const std::vector<std::shared_ptr<CurrencyItem>> &currencies) {
+    rapidjson::Document doc;
+    doc.SetObject();
+    auto &alloc = doc.GetAllocator();
+    for (auto &curr : currencies) {
+        rapidjson::Value item(rapidjson::kObjectType);
+        item.AddMember("count", curr->count, alloc);
+        item.AddMember("chaos_ratio", curr->chaos.value1, alloc);
+        item.AddMember("exalt_ratio", curr->exalt.value1, alloc);
+        Util::RapidjsonAddConstString(&item, "currency", CurrencyAsTag[curr->currency], alloc);
+        rapidjson::Value name(curr->name.c_str(), alloc);
+        doc.AddMember(name, item, alloc);
+    }
+    return Util::RapidjsonSerialize(doc);
+}
+
+void CurrencyManager::Deserialize(const std::string &data, std::vector<std::shared_ptr<CurrencyItem> > *currencies) {
+    //Maybe clear something would be good
+    if (data.empty())
+        return;
+    rapidjson::Document doc;
+    if (doc.Parse(data.c_str()).HasParseError()) {
+        QLOG_ERROR() << "Error while parsing currency ratios.";
+        QLOG_ERROR() << rapidjson::GetParseError_En(doc.GetParseError());
+        return;
+    }
+    if (!doc.IsObject())
+        return;
+    for (auto itr = doc.MemberBegin(); itr != doc.MemberEnd(); ++itr) {
+        auto &object = itr->value;
+        Currency curr = static_cast<Currency>(Util::TagAsCurrency(object["currency"].GetString()));
+        std::shared_ptr<CurrencyItem> item = std::make_shared<CurrencyItem>(object["count"].GetDouble(), curr,
+                object["chaos_ratio"].GetDouble(), object["exalt_ratio"].GetDouble());
+        currencies->push_back(item);
+    }
+}
+
+void CurrencyManager::SaveCurrencyItems() {
+    data_.Set("currency_items", Serialize(currencies_));
 }
 
 void CurrencyManager::SaveCurrencyValue() {
@@ -136,10 +180,10 @@ void CurrencyManager::SaveCurrencyValue() {
     // Useless to save if every count is 0.
     bool empty = true;
     value = std::to_string(TotalExaltedValue());
-    for (auto currency : currencies_) {
-        if (currency.name != "")
-            value += ";" + std::to_string(currency.count);
-        if (currency.count != 0)
+    for (auto &currency : currencies_) {
+        if (currency->name != "")
+            value += ";" + std::to_string(currency->count);
+        if (currency->count != 0)
             empty = false;
     }
     std::string old_value = data_.Get("currency_last_value", "");
@@ -182,8 +226,8 @@ void CurrencyManager::ExportCurrency() {
 
 void CurrencyManager::ParseSingleItem(const Item &item) {
     for (unsigned int i = 0; i < currencies_.size(); i++)
-        if (item.PrettyName() == currencies_[i].name)
-            currencies_[i].count += item.count();
+        if (item.PrettyName() == currencies_[i]->name)
+            currencies_[i]->count += item.count();
 
     for (unsigned int i = 0; i < wisdoms_.size(); i++)
         if (item.PrettyName() == CurrencyForWisdom[i])
@@ -191,78 +235,104 @@ void CurrencyManager::ParseSingleItem(const Item &item) {
 }
 
 void CurrencyManager::DisplayCurrency() {
+
     dialog_->show();
+}
+
+
+CurrencyWidget::CurrencyWidget(std::shared_ptr<CurrencyItem> currency)  :
+    currency_(currency)
+{
+    name_ = new QLabel("");
+    chaos_ratio_ = new QDoubleSpinBox;
+    chaos_ratio_->setMaximum(100000);
+    chaos_ratio_->setValue(currency->chaos.value1);
+    chaos_value_ = new QDoubleSpinBox;
+    chaos_value_->setMaximum(100000);
+    chaos_value_->setEnabled(false);
+    exalt_ratio_ = new QDoubleSpinBox;
+    exalt_ratio_->setMaximum(100000);
+    exalt_ratio_->setValue(currency->exalt.value1);
+    exalt_value_ = new QDoubleSpinBox;
+    exalt_value_->setMaximum(100000);
+    exalt_value_->setEnabled(false);
+    Update();
+    connect(chaos_ratio_, SIGNAL(valueChanged(double)), this, SLOT(Update()));
+    connect(exalt_ratio_, SIGNAL(valueChanged(double)), this, SLOT(Update()));
+}
+
+
+
+void CurrencyWidget::Update() {
+    currency_->chaos.value1 = chaos_ratio_->value();
+    currency_->exalt.value1 = exalt_ratio_->value();
+    std::string text = currency_->name + "(" + std::to_string(currency_->count) + ")";
+    name_->setText(text.c_str());
+    chaos_value_->setValue(currency_->count / currency_->chaos.value1);
+    exalt_value_->setValue(currency_->count / currency_->exalt.value1);
 }
 
 CurrencyDialog::CurrencyDialog(CurrencyManager& manager) : currency_manager_(manager) {
     mapper = new QSignalMapper;
-    connect(mapper, SIGNAL(mapped(int)), this, SLOT(OnBaseValueChanged(int)));
     layout_ = new QGridLayout;
     layout_->addWidget(new QLabel("Name"), 0, 0);
     layout_->addWidget(new QLabel("Value in Exalted Orbs"), 0, 1);
     layout_->addWidget(new QLabel("Amount an Exalted Orb can buy"), 0, 2);
-    for (auto curr : currency_manager_.currencies()) {
-        std::string text = curr.name + " (" + std::to_string(curr.count) + ")";
-        QLabel* tmpName = new QLabel(text.c_str());
-        QDoubleSpinBox* tmpValue = new QDoubleSpinBox;
-        tmpValue->setMaximum(100000);
-        tmpValue->setValue(curr.exalt);
-        tmpValue->setEnabled(false);
-        QDoubleSpinBox* tmpBaseValue = new QDoubleSpinBox;
-        tmpBaseValue->setMaximum(100000);
-        tmpBaseValue->setValue(curr.base);
-        names_.push_back(tmpName);
-        values_.push_back(tmpValue);
-        base_values_.push_back(tmpBaseValue);
+    layout_->addWidget(new QLabel("Value in Chaos Orbs"), 0, 3);
+    layout_->addWidget(new QLabel("Amount a Chaos Orb can buy"), 0, 4);
+    for (auto &curr : currency_manager_.currencies()) {
+        CurrencyWidget* tmp = new CurrencyWidget(curr);
         int curr_row = layout_->rowCount() + 1;
         // To keep every vector the same size, we DO create spinboxes for the empty currency, just don't display them
-        if (curr.name == "")
+        if (curr->currency == CURRENCY_NONE)
             continue;
-        layout_->addWidget(names_.back(), curr_row, 0);
-        layout_->addWidget(values_.back(), curr_row, 1);
-        layout_->addWidget(base_values_.back(), curr_row, 2);
-        mapper->setMapping(base_values_.back(), base_values_.size() - 1);
-        connect(base_values_.back(), SIGNAL(valueChanged(double)), mapper, SLOT(map()));
+        layout_->addWidget(tmp->name_, curr_row, 0);
+        layout_->addWidget(tmp->exalt_value_, curr_row, 1);
+        layout_->addWidget(tmp->exalt_ratio_, curr_row, 2);
+        layout_->addWidget(tmp->chaos_value_, curr_row, 3);
+        layout_->addWidget(tmp->chaos_ratio_, curr_row, 4);
+        connect(tmp->exalt_ratio_, SIGNAL(valueChanged(double)), this, SLOT(UpdateTotalValue()));
+        connect(tmp->chaos_ratio_, SIGNAL(valueChanged(double)), this, SLOT(UpdateTotalValue()));
+
+        currencies_widgets_.push_back(tmp);
+
     }
     int curr_row = layout_->rowCount();
     layout_->addWidget(new QLabel("Total Exalted Orbs"), curr_row, 0);
-    total_value_ = new QDoubleSpinBox;
-    total_value_->setMaximum(100000);
-    total_value_->setEnabled(false);
-    UpdateTotalExaltedValue();
-    layout_->addWidget(total_value_, curr_row, 1);
+    total_exalt_value_ = new QDoubleSpinBox;
+    total_exalt_value_->setMaximum(100000);
+    total_exalt_value_->setEnabled(false);
+    layout_->addWidget(total_exalt_value_, curr_row, 1);
+    layout_->addWidget(new QLabel("Total Chaos Orbs"), curr_row + 1, 0);
+    total_chaos_value_ = new QDoubleSpinBox;
+    total_chaos_value_->setMaximum(100000);
+    total_chaos_value_->setEnabled(false);
+    layout_->addWidget(total_chaos_value_, curr_row + 1, 1);
+
     total_wisdom_value_ = new QDoubleSpinBox;
     total_wisdom_value_->setMaximum(100000);
     total_wisdom_value_->setEnabled(false);
+    UpdateTotalValue();
     UpdateTotalWisdomValue();
-    layout_->addWidget(new QLabel("Total Scrolls of Wisdom"), curr_row + 1, 0);
-    layout_->addWidget(total_wisdom_value_, curr_row + 1, 1);
+    layout_->addWidget(new QLabel("Total Scrolls of Wisdom"), curr_row + 2, 0);
+    layout_->addWidget(total_wisdom_value_, curr_row + 2, 1);
 #if defined(Q_OS_LINUX)
     setWindowFlags(Qt::WindowCloseButtonHint);
 #endif
     setLayout(layout_);
 }
 
-void CurrencyDialog::OnBaseValueChanged(int index) {
-    currency_manager_.UpdateBaseValue(index, base_values_[index]->value());
-    currency_manager_.UpdateExaltedValue();
-    values_[index]->setValue(currency_manager_.currencies()[index].exalt);
-    UpdateTotalExaltedValue();
-}
-
 void CurrencyDialog::Update() {
-    for (unsigned int i = 0; i < values_.size(); i++) {
-        CurrencyItem curr = currency_manager_.currencies()[i];
-        std::string text = curr.name + " (" + std::to_string(curr.count) + ")";
-        names_[i]->setText(text.c_str());
-        values_[i]->setValue(curr.exalt);
+    for (auto widget : currencies_widgets_) {
+        widget->Update();
     }
-    UpdateTotalExaltedValue();
+    UpdateTotalValue();
     UpdateTotalWisdomValue();
 }
 
-void CurrencyDialog::UpdateTotalExaltedValue() {
-    total_value_->setValue(currency_manager_.TotalExaltedValue());
+void CurrencyDialog::UpdateTotalValue() {
+    total_exalt_value_->setValue(currency_manager_.TotalExaltedValue());
+    total_chaos_value_->setValue(currency_manager_.TotalChaosValue());
 }
 
 void CurrencyDialog::UpdateTotalWisdomValue() {

--- a/src/currencymanager.cpp
+++ b/src/currencymanager.cpp
@@ -61,8 +61,8 @@ CurrencyManager::~CurrencyManager() {
 void CurrencyManager::Save() {
     SaveCurrencyItems();
     SaveCurrencyValue();
-    data_.SetBool("currency_show_chaos", dialog_->showChaos());
-    data_.SetBool("currency_show_exalt", dialog_->showExalt());
+    data_.SetBool("currency_show_chaos", dialog_->ShowChaos());
+    data_.SetBool("currency_show_exalt", dialog_->ShowExalt());
 
 }
 
@@ -253,42 +253,42 @@ void CurrencyManager::DisplayCurrency() {
 CurrencyWidget::CurrencyWidget(std::shared_ptr<CurrencyItem> currency)  :
     currency_(currency)
 {
-    name_ = new QLabel("");
-    count_ = new QLabel("");
-    chaos_ratio_ = new QDoubleSpinBox;
-    chaos_ratio_->setMaximum(100000);
-    chaos_ratio_->setValue(currency->chaos.value1);
-    chaos_value_ = new QDoubleSpinBox;
-    chaos_value_->setMaximum(100000);
-    chaos_value_->setEnabled(false);
-    exalt_ratio_ = new QDoubleSpinBox;
-    exalt_ratio_->setMaximum(100000);
-    exalt_ratio_->setValue(currency->exalt.value1);
-    exalt_value_ = new QDoubleSpinBox;
-    exalt_value_->setMaximum(100000);
-    exalt_value_->setEnabled(false);
+    name = new QLabel("");
+    count = new QLabel("");
+    chaos_ratio = new QDoubleSpinBox;
+    chaos_ratio->setMaximum(100000);
+    chaos_ratio->setValue(currency->chaos.value1);
+    chaos_value = new QDoubleSpinBox;
+    chaos_value->setMaximum(100000);
+    chaos_value->setEnabled(false);
+    exalt_ratio = new QDoubleSpinBox;
+    exalt_ratio->setMaximum(100000);
+    exalt_ratio->setValue(currency->exalt.value1);
+    exalt_value = new QDoubleSpinBox;
+    exalt_value->setMaximum(100000);
+    exalt_value->setEnabled(false);
     Update();
-    connect(chaos_ratio_, SIGNAL(valueChanged(double)), this, SLOT(Update()));
-    connect(exalt_ratio_, SIGNAL(valueChanged(double)), this, SLOT(Update()));
+    connect(chaos_ratio, SIGNAL(valueChanged(double)), this, SLOT(Update()));
+    connect(exalt_ratio, SIGNAL(valueChanged(double)), this, SLOT(Update()));
 }
 
 void CurrencyWidget::UpdateVisual(bool show_chaos, bool show_exalt) {
 
-    chaos_value_->setVisible(show_chaos);
-    chaos_ratio_->setVisible(show_chaos);
-    exalt_value_->setVisible(show_exalt);
-    exalt_ratio_->setVisible(show_exalt);
+    chaos_value->setVisible(show_chaos);
+    chaos_ratio->setVisible(show_chaos);
+    exalt_value->setVisible(show_exalt);
+    exalt_ratio->setVisible(show_exalt);
 }
 
 void CurrencyWidget::Update() {
-    currency_->chaos.value1 = chaos_ratio_->value();
-    currency_->exalt.value1 = exalt_ratio_->value();
-    name_->setText(currency_->name.c_str());
-    count_->setText(QString::number(currency_->count));
+    currency_->chaos.value1 = chaos_ratio->value();
+    currency_->exalt.value1 = exalt_ratio->value();
+    name->setText(currency_->name.c_str());
+    count->setText(QString::number(currency_->count));
     if (fabs(currency_->chaos.value1) > EPS)
-        chaos_value_->setValue(currency_->count / currency_->chaos.value1);
+        chaos_value->setValue(currency_->count / currency_->chaos.value1);
     if (fabs(currency_->exalt.value1) > EPS)
-        exalt_value_->setValue(currency_->count / currency_->exalt.value1);
+        exalt_value->setValue(currency_->count / currency_->exalt.value1);
 }
 
 CurrencyDialog::CurrencyDialog(CurrencyManager& manager, bool show_chaos, bool show_exalt) : currency_manager_(manager) {
@@ -298,8 +298,8 @@ CurrencyDialog::CurrencyDialog(CurrencyManager& manager, bool show_chaos, bool s
         // To keep every vector the same size, we DO create spinboxes for the empty currency, just don't display them
         if (curr->currency == CURRENCY_NONE)
             continue;
-        connect(tmp->exalt_ratio_, SIGNAL(valueChanged(double)), this, SLOT(UpdateTotalValue()));
-        connect(tmp->chaos_ratio_, SIGNAL(valueChanged(double)), this, SLOT(UpdateTotalValue()));
+        connect(tmp->exalt_ratio, SIGNAL(valueChanged(double)), this, SLOT(UpdateTotalValue()));
+        connect(tmp->chaos_ratio, SIGNAL(valueChanged(double)), this, SLOT(UpdateTotalValue()));
 
         currencies_widgets_.push_back(tmp);
 
@@ -336,9 +336,9 @@ void CurrencyDialog::Update() {
 void CurrencyDialog::UpdateVisual() {
     //Destroy old layout (because you can't replace a layout, that would be too fun :/)
     delete layout_;
-    layout_ = GenerateLayout(showChaos(), showExalt());
+    layout_ = GenerateLayout(ShowChaos(), ShowExalt());
     setLayout(layout_);
-    UpdateVisibility(showChaos(), showExalt());
+    UpdateVisibility(ShowChaos(), ShowExalt());
     adjustSize();
 }
 
@@ -382,20 +382,20 @@ QVBoxLayout* CurrencyDialog::GenerateLayout(bool show_chaos, bool show_exalt) {
     for (auto &item : currencies_widgets_) {
         int curr_row = grid->rowCount() + 1;
         // To keep every vector the same size, we DO create spinboxes for the empty currency, just don't display them
-        if (item->isNone())
+        if (item->IsNone())
             continue;
-        grid->addWidget(item->name_, curr_row, 0);
-        grid->addWidget(item->count_, curr_row, 1, 1, -1);
+        grid->addWidget(item->name, curr_row, 0);
+        grid->addWidget(item->count, curr_row, 1, 1, -1);
         int col = 2;
 
         if (show_chaos) {
-            grid->addWidget(item->chaos_value_, curr_row, col);
-            grid->addWidget(item->chaos_ratio_, curr_row, col + 1);
+            grid->addWidget(item->chaos_value, curr_row, col);
+            grid->addWidget(item->chaos_ratio, curr_row, col + 1);
             col += 2;
         }
         if (show_exalt) {
-            grid->addWidget(item->exalt_value_, curr_row, col);
-            grid->addWidget(item->exalt_ratio_, curr_row, col + 1);
+            grid->addWidget(item->exalt_value, curr_row, col);
+            grid->addWidget(item->exalt_ratio, curr_row, col + 1);
         }
 
 

--- a/src/currencymanager.h
+++ b/src/currencymanager.h
@@ -140,6 +140,7 @@ public:
 public slots:
     void Update();
     void UpdateVisual();
+    void UpdateVisibility(bool show_chaos, bool show_exalt);
     void UpdateTotalValue();
 private:
     CurrencyManager &currency_manager_;

--- a/src/currencymanager.h
+++ b/src/currencymanager.h
@@ -145,13 +145,14 @@ private:
     CurrencyManager &currency_manager_;
     std::vector<CurrencyWidget*> currencies_widgets_;
     CurrencyLabels *headers_;
-    QGridLayout *layout_;
-    QDoubleSpinBox *total_exalt_value_;
-    QDoubleSpinBox *total_chaos_value_;
-    QDoubleSpinBox *total_wisdom_value_;
+    QVBoxLayout *layout_;
+    QLabel *total_exalt_value_;
+    QLabel *total_chaos_value_;
+    QLabel *total_wisdom_value_;
     QCheckBox *show_chaos_;
     QCheckBox *show_exalt_;
-    QGridLayout* GenerateGrid(bool show_chaos, bool show_exalt);
+    QFrame *separator_;
+    QVBoxLayout* GenerateLayout(bool show_chaos, bool show_exalt);
     void UpdateTotalWisdomValue();
 };
 

--- a/src/currencymanager.h
+++ b/src/currencymanager.h
@@ -88,16 +88,16 @@ class CurrencyWidget : public QWidget
 public slots:
     void Update();
     void UpdateVisual(bool show_chaos, bool show_exalt);
-    bool isNone() const { return currency_->currency==CURRENCY_NONE;}
+    bool IsNone() const { return currency_->currency==CURRENCY_NONE;}
 public:
     CurrencyWidget(std::shared_ptr<CurrencyItem> currency);
     //Visual stuff
-    QLabel *name_;
-    QLabel *count_;
-    QDoubleSpinBox *chaos_ratio_;
-    QDoubleSpinBox *chaos_value_;
-    QDoubleSpinBox *exalt_ratio_;
-    QDoubleSpinBox *exalt_value_;
+    QLabel *name;
+    QLabel *count;
+    QDoubleSpinBox *chaos_ratio;
+    QDoubleSpinBox *chaos_value;
+    QDoubleSpinBox *exalt_ratio;
+    QDoubleSpinBox *exalt_value;
 
 private:
     //Data
@@ -133,9 +133,9 @@ class CurrencyDialog : public QDialog
 {
     Q_OBJECT
 public:
-    CurrencyDialog(CurrencyManager &manager, bool showChaos, bool showExalt);
-    bool showChaos() const { return show_chaos_->isChecked();}
-    bool showExalt() const { return show_exalt_->isChecked();}
+    CurrencyDialog(CurrencyManager &manager, bool show_chaos, bool show_exalt);
+    bool ShowChaos() const { return show_chaos_->isChecked();}
+    bool ShowExalt() const { return show_exalt_->isChecked();}
 
 public slots:
     void Update();

--- a/src/currencymanager.h
+++ b/src/currencymanager.h
@@ -58,17 +58,42 @@ struct CurrencyItem {
     }
 
 };
+struct CurrencyLabels {
+    QLabel *name;
+    QLabel *count;
+    QLabel *chaos_ratio;
+    QLabel *chaos_value;
+    QLabel *exalt_ratio;
+    QLabel *exalt_value;
+    QLabel *exalt_total;
+    QLabel *chaos_total;
+    QLabel *wisdom_total;
+    CurrencyLabels() {
+        name = new QLabel("Name");
+        count = new QLabel("Count");
+        chaos_ratio = new QLabel("Amount a chaos Orb can buy");
+        chaos_value = new QLabel("Value in Chaos Orb");
+        exalt_ratio = new QLabel("Amount an Exalted Orb can buy");
+        exalt_value = new QLabel("Value in Exalted Orb");
+        exalt_total = new QLabel("Total Exalted Orbs");
+        chaos_total = new QLabel("Total Chaos Orbs");
+        wisdom_total = new QLabel("Total Scrolls of Wisdom");
+    }
 
+};
 class CurrencyDialog;
 class CurrencyWidget : public QWidget
 {
     Q_OBJECT
 public slots:
     void Update();
+    void UpdateVisual(bool show_chaos, bool show_exalt);
+    bool isNone() const { return currency_->currency==CURRENCY_NONE;}
 public:
     CurrencyWidget(std::shared_ptr<CurrencyItem> currency);
     //Visual stuff
     QLabel *name_;
+    QLabel *count_;
     QDoubleSpinBox *chaos_ratio_;
     QDoubleSpinBox *chaos_value_;
     QDoubleSpinBox *exalt_ratio_;
@@ -108,21 +133,28 @@ class CurrencyDialog : public QDialog
 {
     Q_OBJECT
 public:
-    CurrencyDialog(CurrencyManager &manager);
+    CurrencyDialog(CurrencyManager &manager, bool showChaos, bool showExalt);
+    bool showChaos() const { return show_chaos_->isChecked();}
+    bool showExalt() const { return show_exalt_->isChecked();}
+
 public slots:
     void Update();
+    void UpdateVisual();
     void UpdateTotalValue();
 private:
     CurrencyManager &currency_manager_;
     std::vector<CurrencyWidget*> currencies_widgets_;
-
+    CurrencyLabels *headers_;
     QGridLayout *layout_;
     QDoubleSpinBox *total_exalt_value_;
     QDoubleSpinBox *total_chaos_value_;
     QDoubleSpinBox *total_wisdom_value_;
-    QSignalMapper *mapper;
+    QCheckBox *show_chaos_;
+    QCheckBox *show_exalt_;
+    QGridLayout* GenerateGrid(bool show_chaos, bool show_exalt);
     void UpdateTotalWisdomValue();
 };
+
 
 class CurrencyManager : public QWidget
 {
@@ -158,7 +190,7 @@ private:
     void SaveCurrencyItems();
     std::string Serialize(const std::vector<std::shared_ptr<CurrencyItem>> &currencies);
     void Deserialize(const std::string &data, std::vector<std::shared_ptr<CurrencyItem>> *currencies);
-
+    void Save();
 public slots:
     void SaveCurrencyValue();
 };


### PR DESCRIPTION
* Allow user to have both of chaos / exalted value conversion (or one of them, or none if he wants to)
* CurrencyItem now uses CurrencyRatio to store the chaos/exalted conversion, with one of the two currency in the ratio beeing fixed (to chaos or exalted)
* Changed the way CurrencyRatios are saved in the database, now use json for serializing/deserializing.
* Should be much more robust if new currencies are added
* Automatically migrates old ratio to new one (yay user experience)
* Slightly altered the visual aspect of the currency dialog

The main goal is to be able to easily support currency.poe.trade APi (if one is coming) since all ratio are between two currencies. It should be fairly easy to add others ratio (simply need 2 QDropDown to select the currency, and QDoubleSpinBox to select the ratio).

I also tried to make the dialog not so shitty (visually speaking), but it's still pretty hard to do. We could consider moving it to a fixed tab (in the searches), the code would stay the same (except we have to inherit from QWidget instead of QDialog, but that's it)

I haven't touched to the export to CSV feature for now, but clearly the way data is saved should be changed : at the moment, adding another currency and moving a header (for example, to add the total in chaos) more or less break the formatting. I was also thinking about serializing to json (since it's fairly easy to do and we already use it elsewhere)

![capture d ecran de 2016-02-09 23-56-28](https://cloud.githubusercontent.com/assets/8601327/12933875/dc07b782-cf8a-11e5-8290-cb6302141ec6.png)
![capture d ecran de 2016-02-09 23-56-25](https://cloud.githubusercontent.com/assets/8601327/12933877/de523a8a-cf8a-11e5-8e1e-222b1c41bb06.png)
![capture d ecran de 2016-02-09 23-56-32](https://cloud.githubusercontent.com/assets/8601327/12933881/e4c9fef2-cf8a-11e5-83e0-69ebe7cb92b5.png)
