### PR TITLE
Add interface update delays to some key areas

### DIFF
--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -82,7 +82,7 @@ void NameSearchFilter::Initialize(QLayout *parent) {
     textbox_ = new QLineEdit;
     parent->addWidget(textbox_);
     QObject::connect(textbox_, SIGNAL(textEdited(const QString&)),
-                     parent->parentWidget()->window(), SLOT(OnSearchFormChange()));
+                     parent->parentWidget()->window(), SLOT(OnDelayedSearchFormChange()));
 }
 
 MinMaxFilter::MinMaxFilter(QLayout *parent, std::string property):
@@ -118,9 +118,9 @@ void MinMaxFilter::Initialize(QLayout *parent) {
     textbox_max_->setFixedWidth(Util::TextWidth(TextWidthId::WIDTH_MIN_MAX));
     label->setFixedWidth(Util::TextWidth(TextWidthId::WIDTH_LABEL));
     QObject::connect(textbox_min_, SIGNAL(textEdited(const QString&)),
-                     parent->parentWidget()->window(), SLOT(OnSearchFormChange()));
+                     parent->parentWidget()->window(), SLOT(OnDelayedSearchFormChange()));
     QObject::connect(textbox_max_, SIGNAL(textEdited(const QString&)),
-                     parent->parentWidget()->window(), SLOT(OnSearchFormChange()));
+                     parent->parentWidget()->window(), SLOT(OnDelayedSearchFormChange()));
 }
 
 void MinMaxFilter::FromForm(FilterData *data) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -92,7 +92,9 @@ MainWindow::MainWindow(std::unique_ptr<Application> app):
     connect(&app_->shop(), &Shop::StatusUpdate, this, &MainWindow::OnStatusUpdate);
     connect(&update_checker_, &UpdateChecker::UpdateAvailable, this, &MainWindow::OnUpdateAvailable);
     connect(&auto_online_, &AutoOnline::Update, this, &MainWindow::OnOnlineUpdate);
-    connect(&update_current_item_trigger_, &QTimer::timeout, [&](){UpdateCurrentItem();update_current_item_trigger_.stop();});
+    connect(&delayed_update_current_item_, &QTimer::timeout, [&](){UpdateCurrentItem();delayed_update_current_item_.stop();});
+    connect(&delayed_search_form_change_, &QTimer::timeout, [&](){OnSearchFormChange();delayed_search_form_change_.stop();});
+
 }
 
 void MainWindow::InitializeLogging() {
@@ -432,6 +434,12 @@ void MainWindow::OnSearchFormChange() {
     tab_bar_->setTabText(tab_bar_->currentIndex(), current_search_->GetCaption());
 }
 
+void MainWindow::OnDelayedSearchFormChange() {
+    // wait 350ms after search form change before applying
+    // This is so we don't force update after every keystroke etc...
+    delayed_search_form_change_.start(350);
+}
+
 void MainWindow::OnTreeChange(const QModelIndex &current, const QModelIndex & /* previous */) {
     app_->buyout_manager().Save();
 
@@ -442,7 +450,7 @@ void MainWindow::OnTreeChange(const QModelIndex &current, const QModelIndex & /*
         UpdateCurrentBucket();
     } else {
         current_item_ = current_search_->buckets()[current.parent().row()]->items()[current.row()];
-        update_current_item_trigger_.start(100);
+        delayed_update_current_item_.start(100);
     }
     UpdateCurrentBuyout();
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -83,6 +83,7 @@ public:
 public slots:
     void OnTreeChange(const QModelIndex &index, const QModelIndex &prev);
     void OnSearchFormChange();
+    void OnDelayedSearchFormChange();
     void OnTabChange(int index);
     void OnImageFetched(QNetworkReply *reply);
     void OnItemsRefreshed();
@@ -154,7 +155,8 @@ private:
     AutoOnline auto_online_;
     QLabel online_label_;
     QNetworkAccessManager *network_manager_;
-    QTimer update_current_item_trigger_;
+    QTimer delayed_update_current_item_;
+    QTimer delayed_search_form_change_;
 #ifdef Q_OS_WIN32
     QWinTaskbarButton *taskbar_button_;
 #endif

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -154,6 +154,7 @@ private:
     AutoOnline auto_online_;
     QLabel online_label_;
     QNetworkAccessManager *network_manager_;
+    QTimer update_current_item_trigger_;
 #ifdef Q_OS_WIN32
     QWinTaskbarButton *taskbar_button_;
 #endif

--- a/src/modsfilter.cpp
+++ b/src/modsfilter.cpp
@@ -99,7 +99,7 @@ ModsFilter::ModsFilter(QLayout *parent):
 {
     Initialize(parent);
     QObject::connect(&signal_handler_, SIGNAL(SearchFormChanged()), 
-        parent->parentWidget()->window(), SLOT(OnSearchFormChange()));
+        parent->parentWidget()->window(), SLOT(OnDelayedSearchFormChange()));
 }
 
 void ModsFilter::FromForm(FilterData *data) {


### PR DESCRIPTION
In a few situations the interface would update at too fast a rate.  The most obvious were selecting a range using multiselect and when typing in words for search.

This patch allows for 350ms delay before search form is processed and 100ms before item info is updated in the right hand pane based on selected items.  Should make for a smoother user experience.