### PR TITLE
Fix compilation error on g++ 5.3

### DIFF
--- a/test/testitemsmanager.cpp
+++ b/test/testitemsmanager.cpp
@@ -87,7 +87,7 @@ void TestItemsManager::UserSetBuyoutPropagation() {
     bo.SetTab(first_tab.GetUniqueHash(), tab_buyout);
 
     Items items = { first, second };
-    auto tabs{ first_tab };
+    auto tabs = { first_tab };
     app_.items_manager().OnItemsRefreshed(items, tabs, true);
 
     QVERIFY2(bo.Exists(*first), "Item buyout for the first item must exist");
@@ -116,7 +116,7 @@ void TestItemsManager::MoveItemNoBoToBo() {
     Buyout tab_buyout(456.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, QDateTime::currentDateTime());
     bo.SetTab(second_tab.GetUniqueHash(), tab_buyout);
 
-    auto tabs{ first_tab, second_tab };
+    auto tabs = { first_tab, second_tab };
     // Put item into the first tab
     app_.items_manager().OnItemsRefreshed({ item_before }, tabs, true);
 
@@ -145,7 +145,7 @@ void TestItemsManager::MoveItemBoToNoBo() {
     Buyout tab_buyout(456.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, QDateTime::currentDateTime());
     bo.SetTab(first_tab.GetUniqueHash(), tab_buyout);
 
-    auto tabs{ first_tab, second_tab };
+    auto tabs = { first_tab, second_tab };
     // Put item into the first tab
     app_.items_manager().OnItemsRefreshed({ item_before }, tabs, true);
 


### PR DESCRIPTION
Since https://github.com/xyzz/acquisition/commit/6edf9ab790dcf7c2bf06fe54693f3f3011b101e0, i have the following error on g++ 5.3 : (i'm assuming it works well on g++-4.6 cause travis is OK, clang compiles fine too)
https://gist.github.com/Gloorf/290c5b2324d8c2ad370a