### PR TITLE
Automatic tab pricing

### DIFF
--- a/acquisition.pro
+++ b/acquisition.pro
@@ -55,6 +55,7 @@ SOURCES += \
     src/util.cpp \
     src/version.cpp \
     src/verticalscrollarea.cpp \
+    src/auto_price.cpp \
     test/testdata.cpp \
     test/testitem.cpp \
     test/testitemsmanager.cpp \
@@ -102,6 +103,7 @@ HEADERS += \
     src/version.h \
     src/version_defines.h \
     src/verticalscrollarea.h \
+    src/auto_price.hpp \
     test/testdata.h \
     test/testitem.h \
     test/testitemsmanager.h \

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -273,6 +273,7 @@
     <addaction name="separator"/>
     <addaction name="actionAutomatically_refresh_items"/>
     <addaction name="actionItems_refresh_interval"/>
+    <addaction name="actionDownloadCharacters"/>
    </widget>
    <widget class="QMenu" name="menuAuto_online">
     <property name="title">
@@ -320,6 +321,17 @@
     <string>Auto refresh interval...</string>
    </property>
   </action>
+  <action name="actionDownloadCharacters">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Download characters</string>
+   </property>
+ </action>
   <action name="actionRefresh">
    <property name="text">
     <string>Refresh all tabs</string>

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -275,6 +275,14 @@
     <addaction name="actionItems_refresh_interval"/>
     <addaction name="actionDownloadCharacters"/>
    </widget>
+   <widget class="QMenu" name="menuAutoPrice">
+    <property name="title">
+     <string>Auto price</string>
+    </property>
+    <addaction name="actionTabsAutoPrice"/>
+    <addaction name="actionTabsLimitDownloads"/>
+    <addaction name="actionTabsAutoPriceRecipes"/>
+   </widget>
    <widget class="QMenu" name="menuAuto_online">
     <property name="title">
      <string>Auto online</string>
@@ -291,6 +299,7 @@
    </widget>
    <addaction name="menuItems"/>
    <addaction name="menuShop"/>
+   <addaction name="menuAutoPrice"/>
    <addaction name="menuAuto_online"/>
    <addaction name="menuCurrency"/>
   </widget>
@@ -319,6 +328,39 @@
   <action name="actionItems_refresh_interval">
    <property name="text">
     <string>Auto refresh interval...</string>
+   </property>
+  </action>
+  <action name="actionTabsAutoPrice">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Automatically set buyout</string>
+   </property>
+  </action>
+  <action name="actionTabsLimitDownloads">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Download only priced tabs</string>
+   </property>
+  </action>
+  <action name="actionTabsAutoPriceRecipes">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Automatically price recipes tabs</string>
    </property>
   </action>
   <action name="actionDownloadCharacters">

--- a/src/auto_price.cpp
+++ b/src/auto_price.cpp
@@ -1,0 +1,157 @@
+/*
+    Copyright 2016 Baptiste Wicht
+
+    This file is part of Acquisition.
+
+    Acquisition is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Acquisition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Acquisition.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sstream>
+#include <iostream>
+
+#include "auto_price.hpp"
+
+namespace {
+
+bool ends_with(const std::string& str, const std::string& end) {
+    if (str.length() >= end.length()) {
+        return str.compare (str.length() - end.length(), end.length(), end) == 0;
+    } else {
+        return false;
+    }
+}
+
+bool starts_with(const std::string& str, const std::string& start){
+    if (str.length() >= start.length()) {
+        return str.compare (0, start.length(), start) == 0;
+    } else {
+        return false;
+    }
+}
+
+bool is_double(const std::string& s){
+    std::istringstream iss(s);
+    double d;
+    char c;
+    return iss >> d && !(iss >> c);
+}
+
+double to_double(const std::string& s){
+    std::istringstream iss(s);
+    double d;
+    iss >> d;
+    return d;
+}
+
+bool is_int(const std::string& s){
+    std::istringstream iss(s);
+    int d;
+    char c;
+    return iss >> d && !(iss >> c);
+}
+
+int to_int(const std::string& s){
+    std::istringstream iss(s);
+    int d;
+    iss >> d;
+    return d;
+}
+
+} //end of anonymous namespace
+
+bool is_auto_priced(const std::string& title, bool recipe, bool talismans){
+    if(ends_with(title, "c")){
+        return is_double({title.begin(), title.begin() + title.size() - 1});
+    } else if(ends_with(title, "f")){
+        return is_double({title.begin(), title.begin() + title.size() - 1});
+    } else if(ends_with(title, "alt")){
+        return is_double({title.begin(), title.begin() + title.size() - 3});
+    } else if(ends_with(title, "chi")){
+        return is_double({title.begin(), title.begin() + title.size() - 3});
+    } else if(ends_with(title, "alc")){
+        return is_double({title.begin(), title.begin() + title.size() - 3});
+    } else if(ends_with(title, "ex")){
+        return is_double({title.begin(), title.begin() + title.size() - 2});
+    }
+
+    // Automatically price recipes
+    if(recipe){
+        // Chaos and Regals Recipes
+        if(starts_with(title, "C")){
+            return is_int({title.begin() + 1, title.end()});
+        } else if(starts_with(title, "R")){
+            return is_int({title.begin() + 1, title.end()});
+        }
+
+        // Flask Crafting
+        else if(starts_with(title, "F_C")){
+            return title.size() == 3 || is_int({title.begin() + 3, title.end()});
+        } else if(starts_with(title, "F_R")){
+            return title.size() == 3 || is_int({title.begin() + 3, title.end()});
+        }
+    }
+
+    // Automatically price talismans tabs
+    if(talismans){
+        if(starts_with(title, "T")){
+            return is_int({title.begin() + 1, title.end()});
+        }
+    }
+
+    return false;
+}
+
+Buyout get_auto_price(const std::string& title, bool recipe, bool talismans){
+    if(ends_with(title, "c")){
+        return {to_double({title.begin(), title.begin() + title.size() - 1}), BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
+    } else if(ends_with(title, "f")){
+        return {to_double({title.begin(), title.begin() + title.size() - 1}), BUYOUT_TYPE_BUYOUT, CURRENCY_ORB_OF_FUSING, {}};
+    } else if(ends_with(title, "alt")){
+        return {to_double({title.begin(), title.begin() + title.size() - 3}), BUYOUT_TYPE_BUYOUT, CURRENCY_ORB_OF_ALTERATION, {}};
+    } else if(ends_with(title, "chi")){
+        return {to_double({title.begin(), title.begin() + title.size() - 3}), BUYOUT_TYPE_BUYOUT, CURRENCY_CARTOGRAPHERS_CHISEL, {}};
+    } else if(ends_with(title, "alc")){
+        return {to_double({title.begin(), title.begin() + title.size() - 3}), BUYOUT_TYPE_BUYOUT, CURRENCY_ORB_OF_ALCHEMY, {}};
+    } else if(ends_with(title, "ex")){
+        return {to_double({title.begin(), title.begin() + title.size() - 2}), BUYOUT_TYPE_BUYOUT, CURRENCY_EXALTED_ORB, {}};
+    }
+
+    // Automatically price recipes
+    if(recipe){
+        // Chaos and Regals Recipes
+        if(starts_with(title, "C")){
+            return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
+        } else if(starts_with(title, "R")){
+            return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
+        }
+
+        // Flask Crafting
+        else if(starts_with(title, "F_C")){
+            return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
+        } else if(starts_with(title, "F_R")){
+            return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
+        }
+    }
+
+    // Automatically price talismans tabs
+    if(talismans){
+        if(starts_with(title, "T")){
+            return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
+        }
+    }
+
+    std::cerr << "get_auto_price should never be called on non-auto priced tabs" << std::endl;
+
+    return {};
+}

--- a/src/auto_price.cpp
+++ b/src/auto_price.cpp
@@ -70,7 +70,7 @@ int to_int(const std::string& s){
 
 } //end of anonymous namespace
 
-bool is_auto_priced(const std::string& title, bool recipe, bool talismans){
+bool is_auto_priced(const std::string& title, bool recipe){
     if(ends_with(title, "c")){
         return is_double({title.begin(), title.begin() + title.size() - 1});
     } else if(ends_with(title, "f")){
@@ -102,17 +102,10 @@ bool is_auto_priced(const std::string& title, bool recipe, bool talismans){
         }
     }
 
-    // Automatically price talismans tabs
-    if(talismans){
-        if(starts_with(title, "T")){
-            return is_int({title.begin() + 1, title.end()});
-        }
-    }
-
     return false;
 }
 
-Buyout get_auto_price(const std::string& title, bool recipe, bool talismans){
+Buyout get_auto_price(const std::string& title, bool recipe){
     if(ends_with(title, "c")){
         return {to_double({title.begin(), title.begin() + title.size() - 1}), BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
     } else if(ends_with(title, "f")){
@@ -140,13 +133,6 @@ Buyout get_auto_price(const std::string& title, bool recipe, bool talismans){
         else if(starts_with(title, "F_C")){
             return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
         } else if(starts_with(title, "F_R")){
-            return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
-        }
-    }
-
-    // Automatically price talismans tabs
-    if(talismans){
-        if(starts_with(title, "T")){
             return {1.0, BUYOUT_TYPE_BUYOUT, CURRENCY_CHAOS_ORB, {}};
         }
     }

--- a/src/auto_price.hpp
+++ b/src/auto_price.hpp
@@ -21,5 +21,5 @@
 
 #include "buyoutmanager.h"
 
-bool is_auto_priced(const std::string& title, bool recipe = false, bool talismans = false);
-Buyout get_auto_price(const std::string& title, bool recipe = false, bool talismans = false);
+bool is_auto_priced(const std::string& title, bool recipe = false);
+Buyout get_auto_price(const std::string& title, bool recipe = false);

--- a/src/auto_price.hpp
+++ b/src/auto_price.hpp
@@ -1,0 +1,25 @@
+/*
+    Copyright 2016 Baptiste Wicht
+
+    This file is part of Acquisition.
+
+    Acquisition is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Acquisition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Acquisition.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "buyoutmanager.h"
+
+bool is_auto_priced(const std::string& title, bool recipe = false, bool talismans = false);
+Buyout get_auto_price(const std::string& title, bool recipe = false, bool talismans = false);

--- a/src/itemsmanager.cpp
+++ b/src/itemsmanager.cpp
@@ -41,6 +41,9 @@ ItemsManager::ItemsManager(Application &app) :
 {
     auto_update_interval_ = std::stoi(data_.Get("autoupdate_interval", "30"));
     auto_update_ = data_.GetBool("autoupdate", true);
+    auto_price_ = data_.GetBool("autoprice", false);
+    auto_price_recipes_ = data_.GetBool("autopricerecipes", false);
+    limit_downloads_ = data_.GetBool("limitdownloads", false);
     download_characters_ = data_.GetBool("downloadcharacters", true);
     SetAutoUpdateInterval(auto_update_interval_);
     connect(auto_update_timer_.get(), SIGNAL(timeout()), this, SLOT(OnAutoRefreshTimer()));
@@ -140,6 +143,21 @@ void ItemsManager::SetAutoUpdateInterval(int minutes) {
     auto_update_interval_ = minutes;
     if (auto_update_)
         auto_update_timer_->start(auto_update_interval_ * 60 * 1000);
+}
+
+void ItemsManager::SetAutoPrice(bool price) {
+    data_.SetBool("autoprice", price);
+    auto_price_ = price;
+}
+
+void ItemsManager::SetAutoPriceRecipes(bool price) {
+    data_.SetBool("autopricerecipes", price);
+    auto_price_recipes_ = price;
+}
+
+void ItemsManager::SetLimitDownloads(bool limit) {
+    data_.SetBool("limitdownloads", limit);
+    limit_downloads_ = limit;
 }
 
 void ItemsManager::SetDownloadCharacters(bool download) {

--- a/src/itemsmanager.cpp
+++ b/src/itemsmanager.cpp
@@ -41,6 +41,7 @@ ItemsManager::ItemsManager(Application &app) :
 {
     auto_update_interval_ = std::stoi(data_.Get("autoupdate_interval", "30"));
     auto_update_ = data_.GetBool("autoupdate", true);
+    download_characters_ = data_.GetBool("downloadcharacters", true);
     SetAutoUpdateInterval(auto_update_interval_);
     connect(auto_update_timer_.get(), SIGNAL(timeout()), this, SLOT(OnAutoRefreshTimer()));
 }
@@ -139,6 +140,11 @@ void ItemsManager::SetAutoUpdateInterval(int minutes) {
     auto_update_interval_ = minutes;
     if (auto_update_)
         auto_update_timer_->start(auto_update_interval_ * 60 * 1000);
+}
+
+void ItemsManager::SetDownloadCharacters(bool download) {
+    data_.SetBool("downloadcharacters", download);
+    download_characters_ = download;
 }
 
 void ItemsManager::OnAutoRefreshTimer() {

--- a/src/itemsmanager.h
+++ b/src/itemsmanager.h
@@ -48,10 +48,17 @@ public:
     void Update(TabCache::Policy policy = TabCache::DefaultCache, const std::vector<ItemLocation>& tab_names = std::vector<ItemLocation>());
     void SetAutoUpdateInterval(int minutes);
     void SetAutoUpdate(bool update);
+    void SetAutoPrice(bool price);
+    void SetAutoPriceRecipes(bool price);
+    void SetLimitDownloads(bool limit);
     void SetDownloadCharacters(bool download);
     int auto_update_interval() const { return auto_update_interval_; }
     bool auto_update() const { return auto_update_; }
+    bool auto_price() const { return auto_price_; }
+    bool auto_price_recipes() const { return auto_price_recipes_; }
+    bool limit_downloads() const { return limit_downloads_; }
     bool download_characters() const { return download_characters_; }
+
     const Items &items() const { return items_; }
     void PropagateTabBuyouts();
 public slots:
@@ -69,6 +76,16 @@ private:
 
     // should items be automatically refreshed
     bool auto_update_;
+
+    // should tabs be automatically priced
+    bool auto_price_;
+
+    // should recipe tabs be automatically priced
+    bool auto_price_recipes_;
+
+    // should only priced tabs be automatically downloaded
+    bool limit_downloads_;
+
     // should characters be downloaded
     bool download_characters_;
     // items will be automatically updated every X minutes

--- a/src/itemsmanager.h
+++ b/src/itemsmanager.h
@@ -48,8 +48,10 @@ public:
     void Update(TabCache::Policy policy = TabCache::DefaultCache, const std::vector<ItemLocation>& tab_names = std::vector<ItemLocation>());
     void SetAutoUpdateInterval(int minutes);
     void SetAutoUpdate(bool update);
+    void SetDownloadCharacters(bool download);
     int auto_update_interval() const { return auto_update_interval_; }
     bool auto_update() const { return auto_update_; }
+    bool download_characters() const { return download_characters_; }
     const Items &items() const { return items_; }
     void PropagateTabBuyouts();
 public slots:
@@ -67,6 +69,8 @@ private:
 
     // should items be automatically refreshed
     bool auto_update_;
+    // should characters be downloaded
+    bool download_characters_;
     // items will be automatically updated every X minutes
     int auto_update_interval_;
     std::unique_ptr<QTimer> auto_update_timer_;

--- a/src/itemsmanagerworker.cpp
+++ b/src/itemsmanagerworker.cpp
@@ -40,6 +40,7 @@
 #include "mainwindow.h"
 #include "buyoutmanager.h"
 #include "filesystem.h"
+#include "auto_price.hpp"
 
 const char *kStashItemsUrl = "https://www.pathofexile.com/character-window/get-stash-items";
 const char *kCharacterItemsUrl = "https://www.pathofexile.com/character-window/get-items";
@@ -298,15 +299,30 @@ void ItemsManagerWorker::OnFirstTabReceived() {
     tabs_as_string_ = Util::RapidjsonSerialize(doc["tabs"]);
 
     QLOG_DEBUG() << "Received tabs list, there are" << doc["tabs"].Size() << "tabs";
+
+    auto auto_price = application.items_manager().auto_price();
+    auto limit_downloads = application.items_manager().limit_downloads();
+    auto price_recipes = application.items_manager().auto_price_recipes();
+
     tabs_.clear();
 
     // Create tab location objects
     for (auto &tab : doc["tabs"]) {
         std::string label = tab["n"].GetString();
         auto index = tab["i"].GetInt();
-        // Ignore hidden locations
-        if (!doc["tabs"][index].HasMember("hidden") || !doc["tabs"][index]["hidden"].GetBool())
-            tabs_.push_back(ItemLocation(index, label, ItemLocationType::STASH));
+
+        if(!limit_downloads || is_auto_priced(label, price_recipes)){
+            // Ignore hidden locations
+            if (!doc["tabs"][index].HasMember("hidden") || !doc["tabs"][index]["hidden"].GetBool()){
+                ItemLocation location(index, label, ItemLocationType::STASH);
+
+                if(auto_price && is_auto_priced(label, price_recipes)){
+                    application.buyout_manager().SetTab(location.GetUniqueHash(), get_auto_price(label, price_recipes));
+                }
+
+                tabs_.push_back(location);
+            }
+        }
     }
 
     // Immediately parse items received from this tab (first_fetch_tab_) and Queue requests for the others
@@ -317,6 +333,10 @@ void ItemsManagerWorker::OnFirstTabReceived() {
         } else {
             QueueRequest(MakeTabRequest(index, tab), tab);
         }
+    }
+
+    if(auto_price){
+        application.items_manager().PropagateTabBuyouts();
     }
 
     total_needed_ = queue_.size() + 1;

--- a/src/itemsmanagerworker.h
+++ b/src/itemsmanagerworker.h
@@ -81,6 +81,7 @@ private:
     void ParseItems(rapidjson::Value *value_ptr, const ItemLocation &base_location, rapidjson_allocator &alloc);
 
     QNetworkRequest Request(QUrl url, const ItemLocation &location, TabCache::Flags flags = TabCache::None);
+    Application& application;
     DataStore &data_;
     QNetworkAccessManager network_manager_;
     QSignalMapper *signal_mapper_;
@@ -91,7 +92,7 @@ private:
     int total_completed_, total_needed_, total_cached_;
     int requests_completed_, requests_needed_;
     int cached_requests_completed_{0};
-    
+
     std::string tabs_as_string_;
     std::string league_;
     // set to true if updating right now

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -136,6 +136,9 @@ void MainWindow::InitializeUi() {
     connect(ui->buyoutValueLineEdit, SIGNAL(textEdited(QString)), this, SLOT(OnBuyoutChange()));
 
     ui->actionAutomatically_refresh_items->setChecked(app_->items_manager().auto_update());
+    ui->actionTabsAutoPrice->setChecked(app_->items_manager().auto_price());
+    ui->actionTabsAutoPriceRecipes->setChecked(app_->items_manager().auto_price_recipes());
+    ui->actionTabsLimitDownloads->setChecked(app_->items_manager().limit_downloads());
     ui->actionDownloadCharacters->setChecked(app_->items_manager().download_characters());
     UpdateShopMenu();
 
@@ -716,6 +719,18 @@ void MainWindow::on_actionShop_template_triggered() {
 
 void MainWindow::on_actionAutomatically_update_shop_triggered() {
     app_->shop().SetAutoUpdate(ui->actionAutomatically_update_shop->isChecked());
+}
+
+void MainWindow::on_actionTabsAutoPrice_triggered() {
+    app_->items_manager().SetAutoPrice(ui->actionTabsAutoPrice->isChecked());
+}
+
+void MainWindow::on_actionTabsLimitDownloads_triggered() {
+    app_->items_manager().SetLimitDownloads(ui->actionTabsLimitDownloads->isChecked());
+}
+
+void MainWindow::on_actionTabsAutoPriceRecipes_triggered() {
+    app_->items_manager().SetAutoPriceRecipes(ui->actionTabsAutoPriceRecipes->isChecked());
 }
 
 void MainWindow::on_actionControl_poe_xyz_is_URL_triggered() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -136,6 +136,7 @@ void MainWindow::InitializeUi() {
     connect(ui->buyoutValueLineEdit, SIGNAL(textEdited(QString)), this, SLOT(OnBuyoutChange()));
 
     ui->actionAutomatically_refresh_items->setChecked(app_->items_manager().auto_update());
+    ui->actionDownloadCharacters->setChecked(app_->items_manager().download_characters());
     UpdateShopMenu();
 
     search_form_layout_ = new QVBoxLayout;
@@ -730,6 +731,10 @@ void MainWindow::on_actionControl_poe_xyz_is_URL_triggered() {
 void MainWindow::on_actionAutomatically_refresh_online_status_triggered() {
     auto_online_.SetEnabled(ui->actionAutomatically_refresh_online_status->isChecked());
     UpdateOnlineGui();
+}
+
+void MainWindow::on_actionDownloadCharacters_triggered(){
+    app_->items_manager().SetDownloadCharacters(ui->actionDownloadCharacters->isChecked());
 }
 
 void MainWindow::on_actionList_currency_triggered() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -107,6 +107,7 @@ private slots:
     void on_actionRefresh_triggered();
     void on_actionRefresh_selected_triggered();
     void on_actionAutomatically_refresh_items_triggered();
+    void on_actionDownloadCharacters_triggered();
     void on_actionUpdate_shop_triggered();
     void on_actionShop_template_triggered();
     void on_actionAutomatically_update_shop_triggered();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -107,6 +107,9 @@ private slots:
     void on_actionRefresh_triggered();
     void on_actionRefresh_selected_triggered();
     void on_actionAutomatically_refresh_items_triggered();
+    void on_actionTabsAutoPrice_triggered();
+    void on_actionTabsAutoPriceRecipes_triggered();
+    void on_actionTabsLimitDownloads_triggered();
     void on_actionDownloadCharacters_triggered();
     void on_actionUpdate_shop_triggered();
     void on_actionShop_template_triggered();


### PR DESCRIPTION
This patch adds automatic tab pricing for acquisition: 
* Option to automatically set buyouts on tabs based on their labels (1.5ex, 4c, 5alt, ...) (supports ex, chaos, fuse, alt, chisels, alchemy)
* Option to only download tabs that are automatically priced
* Option to automatically set a price of 1 chaos on chaos/regal recipes tabs (C1-9, R1-9)
* Unrelated: Add option to not download characters

By default, nothing is enabled, therefore the behaviour doesn't change. 

This has several advantages. It will download very few tabs. And especially, in a league, you dont' need to do anything in acquisition with buyouts, everything will be automatically updated, which is, imho, really good. 

I can easily add support for more orbs (or for all of them), if you want. 

P.S. I hope I haven't screwed your code style too much, my conventions are very far from yours. 