### PR TITLE
Allow the use of a script to detect processes

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -279,6 +279,7 @@
      <string>Auto online</string>
     </property>
     <addaction name="actionControl_poe_xyz_is_URL"/>
+    <addaction name="actionRemoteScript"/>
     <addaction name="actionAutomatically_refresh_online_status"/>
    </widget>
    <widget class="QMenu" name="menuCurrency">
@@ -349,6 +350,11 @@
   <action name="actionControl_poe_xyz_is_URL">
    <property name="text">
     <string>control.poe.trade URL...</string>
+   </property>
+  </action>
+  <action name="actionRemoteScript">
+   <property name="text">
+    <string>Process list script</string>
    </property>
   </action>
   <action name="actionAutomatically_refresh_online_status">

--- a/src/autoonline.cpp
+++ b/src/autoonline.cpp
@@ -31,25 +31,9 @@
 #include "datastore.h"
 #include "version.h"
 
-// check for PoE running every minute
-const int kOnlineCheckInterval = 60 * 1000;
+namespace {
 
-AutoOnline::AutoOnline(DataStore &data, DataStore &sensitive_data) :
-    data_(data),
-    sensitive_data_(sensitive_data),
-    enabled_(data_.GetBool("online_enabled")),
-    url_(sensitive_data_.Get("online_url")),
-    previous_status_(true)  // set to true to force first refresh
-{
-    timer_.setInterval(kOnlineCheckInterval);
-    connect(&timer_, &QTimer::timeout, this, &AutoOnline::Check);
-    if (enabled_) {
-        timer_.start();
-        Check();
-    }
-}
-
-static bool IsPoeRunning() {
+bool is_poe_running_locally() {
 #if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
     QProcess process;
     process.start("/bin/sh -c \"ps -ax|grep PathOfExile.exe|grep -v grep|wc -l\"");
@@ -91,6 +75,44 @@ static bool IsPoeRunning() {
 #endif
 }
 
+bool is_poe_running_remotely(const std::string& script) {
+#if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
+    std::string poe_check_script = "/bin/sh -c \"" + script + "|grep PathOfExile|grep -v grep|wc -l\"";
+
+    QProcess process;
+    process.start(poe_check_script.c_str());
+    process.waitForFinished(-1);
+
+    QString i = process.readAllStandardOutput();
+    return i.toInt() > 0;
+#elif defined(Q_OS_WIN)
+    QLOG_ERROR() << "Script handling has not been implemented on Windows";
+    return false;
+#endif
+}
+
+
+} //end of anonymous namespace
+
+// check for PoE running every minute
+const int kOnlineCheckInterval = 60 * 1000;
+
+AutoOnline::AutoOnline(DataStore &data, DataStore &sensitive_data) :
+    data_(data),
+    sensitive_data_(sensitive_data),
+    enabled_(data_.GetBool("online_enabled")),
+    url_(sensitive_data_.Get("online_url")),
+    process_script_(sensitive_data_.Get("process_script")),
+    previous_status_(true)  // set to true to force first refresh
+{
+    timer_.setInterval(kOnlineCheckInterval);
+    connect(&timer_, &QTimer::timeout, this, &AutoOnline::Check);
+    if (enabled_) {
+        timer_.start();
+        Check();
+    }
+}
+
 void AutoOnline::SendOnlineUpdate(bool online) {
     // online: true  -> Go online
     // online: false -> Go offline
@@ -105,11 +127,17 @@ void AutoOnline::SendOnlineUpdate(bool online) {
 }
 
 void AutoOnline::Check() {
-    bool running = IsPoeRunning();
+    bool running = is_poe_running_locally();
+    if(IsRemoteScriptSet()){
+        running = is_poe_running_remotely(process_script_);
+    } else {
+        running = is_poe_running_locally();
+    }
 
     if (running || previous_status_) {
         SendOnlineUpdate(running);
     }
+
     previous_status_ = running;
 
     emit Update(running);
@@ -130,6 +158,11 @@ void AutoOnline::SetUrl(const std::string &url) {
     while (url_.size() > 0 && url_[url_.size() - 1] == '/')
         url_.erase(url_.size() - 1);
     sensitive_data_.Set("online_url", url_);
+}
+
+void AutoOnline::SetRemoteScript(const std::string& path) {
+    process_script_ = path;
+    sensitive_data_.Set("process_script", path);
 }
 
 void AutoOnline::SetEnabled(bool enabled) {

--- a/src/autoonline.cpp
+++ b/src/autoonline.cpp
@@ -162,7 +162,7 @@ void AutoOnline::SetUrl(const std::string &url) {
 
 void AutoOnline::SetRemoteScript(const std::string& path) {
     process_script_ = path;
-    data.Set("process_script", path);
+    data_.Set("process_script", path);
 }
 
 void AutoOnline::SetEnabled(bool enabled) {

--- a/src/autoonline.cpp
+++ b/src/autoonline.cpp
@@ -77,14 +77,13 @@ bool is_poe_running_locally() {
 
 bool is_poe_running_remotely(const std::string& script) {
 #if defined(Q_OS_LINUX) || defined(Q_OS_MAC)
-    std::string poe_check_script = "/bin/sh -c \"" + script + "|grep PathOfExile|grep -v grep|wc -l\"";
+    std::string poe_check_script = "/bin/sh -c \"" + script + "\"";
 
     QProcess process;
     process.start(poe_check_script.c_str());
     process.waitForFinished(-1);
 
-    QString i = process.readAllStandardOutput();
-    return i.toInt() > 0;
+    return process.exitCode() == 0;
 #elif defined(Q_OS_WIN)
     QLOG_ERROR() << "Script handling has not been implemented on Windows";
     return false;

--- a/src/autoonline.cpp
+++ b/src/autoonline.cpp
@@ -102,7 +102,7 @@ AutoOnline::AutoOnline(DataStore &data, DataStore &sensitive_data) :
     sensitive_data_(sensitive_data),
     enabled_(data_.GetBool("online_enabled")),
     url_(sensitive_data_.Get("online_url")),
-    process_script_(sensitive_data_.Get("process_script")),
+    process_script_(data.Get("process_script")),
     previous_status_(true)  // set to true to force first refresh
 {
     timer_.setInterval(kOnlineCheckInterval);
@@ -162,7 +162,7 @@ void AutoOnline::SetUrl(const std::string &url) {
 
 void AutoOnline::SetRemoteScript(const std::string& path) {
     process_script_ = path;
-    sensitive_data_.Set("process_script", path);
+    data.Set("process_script", path);
 }
 
 void AutoOnline::SetEnabled(bool enabled) {

--- a/src/autoonline.h
+++ b/src/autoonline.h
@@ -33,7 +33,9 @@ public:
     void SetEnabled(bool enabled);
     bool enabled() { return enabled_; }
     bool IsUrlSet() { return !url_.empty(); }
+    bool IsRemoteScriptSet() { return !process_script_.empty(); }
     void SendOnlineUpdate(bool online);
+    void SetRemoteScript(const std::string& script);
 public slots:
     void Check();
 signals:
@@ -43,6 +45,7 @@ private:
     DataStore &sensitive_data_;
     bool enabled_;
     std::string url_;
+    std::string process_script_;
     bool previous_status_;
     QTimer timer_;
     QNetworkAccessManager nm_;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -656,11 +656,6 @@ void MainWindow::UpdateShopMenu() {
         title += " [" + Util::StringJoin(app_->shop().threads(), ",") + "]";
     ui->actionForum_shop_thread->setText(title.c_str());
     ui->actionAutomatically_update_shop->setChecked(app_->shop().auto_update());
-
-    std::string action_label = "Remote process list script";
-    if (auto_online_.IsRemoteScriptSet())
-        action_label += " [******]";
-    ui->actionRemoteScript->setText(action_label.c_str());
 }
 
 void MainWindow::UpdateOnlineGui() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -113,6 +113,11 @@ void MainWindow::InitializeLogging() {
 
 void MainWindow::InitializeUi() {
     ui->setupUi(this);
+
+#ifndef Q_OS_LINUX
+    ui->menuAuto_online->removeAction(ui->actionRemoteScript);
+#endif
+
     status_bar_label_ = new QLabel("Ready");
     statusBar()->addWidget(status_bar_label_);
     ui->itemLayout->setAlignment(Qt::AlignTop);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -651,6 +651,11 @@ void MainWindow::UpdateShopMenu() {
         title += " [" + Util::StringJoin(app_->shop().threads(), ",") + "]";
     ui->actionForum_shop_thread->setText(title.c_str());
     ui->actionAutomatically_update_shop->setChecked(app_->shop().auto_update());
+
+    std::string action_label = "Remote process list script";
+    if (auto_online_.IsRemoteScriptSet())
+        action_label += " [******]";
+    ui->actionRemoteScript->setText(action_label.c_str());
 }
 
 void MainWindow::UpdateOnlineGui() {
@@ -724,6 +729,16 @@ void MainWindow::on_actionControl_poe_xyz_is_URL_triggered() {
         QLineEdit::Normal, "", &ok);
     if (ok && !url.isEmpty())
         auto_online_.SetUrl(url.toStdString());
+    UpdateOnlineGui();
+}
+
+void MainWindow::on_actionRemoteScript_triggered() {
+    bool ok;
+    QString path = QInputDialog::getText(this, "Remote Process List Script",
+        "Path to the script for listing the running processes of your gaming machine",
+        QLineEdit::Normal, "", &ok);
+    if (ok && !path.isEmpty())
+        auto_online_.SetRemoteScript(path.toStdString());
     UpdateOnlineGui();
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -111,6 +111,7 @@ private slots:
     void on_actionShop_template_triggered();
     void on_actionAutomatically_update_shop_triggered();
     void on_actionControl_poe_xyz_is_URL_triggered();
+    void on_actionRemoteScript_triggered();
     void on_actionAutomatically_refresh_online_status_triggered();
     void on_actionList_currency_triggered();
     void on_actionExport_currency_triggered();


### PR DESCRIPTION
This small patch allows the use of a script to detect running processes. 

For people like me who run/develop acquisition on Linux and play on Windows, this is allows automatically setting online status based on a remote machine. 

I've only implemented this on Linux, the menu is disabled on other systems. 