### PR TITLE
Encapsulation work, current offer

### DIFF
--- a/src/column.cpp
+++ b/src/column.cpp
@@ -161,19 +161,13 @@ std::string PriceColumn::name() {
 }
 
 std::string PriceColumn::value(const Item &item) {
-    if (!bo_manager_.Exists(item))
-        return "";
     const Buyout &bo = bo_manager_.Get(item);
-    return Util::BuyoutAsText(bo);
+    return bo.AsText();
 }
 
 QColor PriceColumn::color(const Item &item) {
-    if (bo_manager_.Exists(item)) {
-        const Buyout &bo = bo_manager_.Get(item);
-        if (bo.inherited)
-            return QColor(0xaa, 0xaa, 0xaa);
-    }
-    return QColor();
+    const Buyout &bo = bo_manager_.Get(item);
+    return bo.IsInherited() ? QColor(0xaa, 0xaa, 0xaa):QColor();
 }
 
 DateColumn::DateColumn(const BuyoutManager &bo_manager):
@@ -185,12 +179,8 @@ std::string DateColumn::name() {
 }
 
 std::string DateColumn::value(const Item &item) {
-    if (!bo_manager_.Exists(item))
-        return "";
-
     const Buyout &bo = bo_manager_.Get(item);
-    return Util::TimeAgoInWords(bo.last_update);
-
+    return bo.IsActive() ? Util::TimeAgoInWords(bo.last_update):"";
 }
 
 std::string ItemlevelColumn::name() {

--- a/src/currencymanager.h
+++ b/src/currencymanager.h
@@ -52,7 +52,7 @@ struct CurrencyItem {
     CurrencyItem(int co, Currency curr, double chaos_ratio, double exalt_ratio) {
         count = co;
         currency = curr;
-        name = CurrencyAsString[curr];
+        name = curr.AsString();
         chaos = CurrencyRatio(currency, CURRENCY_CHAOS_ORB, chaos_ratio, 1);
         exalt = CurrencyRatio(currency, CURRENCY_EXALTED_ORB, exalt_ratio, 1);
     }
@@ -88,7 +88,7 @@ class CurrencyWidget : public QWidget
 public slots:
     void Update();
     void UpdateVisual(bool show_chaos, bool show_exalt);
-    bool IsNone() const { return currency_->currency==CURRENCY_NONE;}
+    bool IsNone() const { return currency_->currency.type==CURRENCY_NONE;}
 public:
     CurrencyWidget(std::shared_ptr<CurrencyItem> currency);
     //Visual stuff

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -395,10 +395,7 @@ bool AltartFilter::Matches(const std::shared_ptr<Item> &item, FilterData *data) 
 bool PricedFilter::Matches(const std::shared_ptr<Item> &item, FilterData *data) {
     if (!data->checked)
         return true;
-    if (!bm_.Exists(*item))
-        return false;
-    Buyout bo = bm_.Get(*item);
-    return bo.type != BuyoutType::BUYOUT_TYPE_NONE;
+    return bm_.Get(*item).IsActive();
 }
 
 double ItemlevelFilter::GetValue(const std::shared_ptr<Item> &item) {

--- a/src/items_model.cpp
+++ b/src/items_model.cpp
@@ -89,8 +89,9 @@ QVariant ItemsModel::data(const QModelIndex &index, int role) const {
         }
         if (role == Qt::DisplayRole) {
             QString title(location.GetHeader().c_str());
-            if (bo_manager_.ExistsTab(location.GetUniqueHash()))
-                title += QString(" [%1]").arg(Util::BuyoutAsText(bo_manager_.GetTab(location.GetUniqueHash())).c_str());
+            auto const &bo = bo_manager_.GetTab(location.GetUniqueHash());
+            if (bo.IsActive())
+                title += QString(" [%1]").arg(bo.AsText().c_str());
             return title;
         }
         return QVariant();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -129,7 +129,6 @@ private:
     void AddSearchGroup(QLayout *layout, const std::string &name);
     bool eventFilter(QObject *o, QEvent *e);
     void UpdateShopMenu();
-    void ResetBuyoutWidgets();
     void UpdateBuyoutWidgets(const Buyout &bo);
     void ExpandCollapse(TreeState state);
     void UpdateOnlineGui();

--- a/src/shop.cpp
+++ b/src/shop.cpp
@@ -74,9 +74,9 @@ void Shop::SetShopTemplate(const std::string &shop_template) {
 }
 std::string Shop::SpoilerBuyout(Buyout &bo) {
     std::string out = "";
-    out += "[spoiler=\"" + BuyoutTypeAsPrefix[bo.type];
-    if (bo.type == BUYOUT_TYPE_BUYOUT || bo.type == BUYOUT_TYPE_FIXED)
-        out += " " + QString::number(bo.value).toStdString() + " "+ CurrencyAsTag[bo.currency];
+    out += "[spoiler=\"" + bo.BuyoutTypeAsPrefix();
+    if (bo.IsPriced())
+        out += " " + QString::number(bo.value).toStdString() + " "+ bo.CurrencyAsTag();
     out += "\"]";
     return out;
 }
@@ -94,15 +94,9 @@ void Shop::Update() {
     //Get all buyouts to be able to sort them
     for (auto &item : app_.items_manager().items()) {
         tmp.item = item.get();
-        tmp.bo.type = BUYOUT_TYPE_NONE;
-        std::string hash = item->location().GetUniqueHash();
-        if (app_.buyout_manager().ExistsTab(hash))
-            tmp.bo = app_.buyout_manager().GetTab(hash);
-        if (app_.buyout_manager().Exists(*item))
-            tmp.bo = app_.buyout_manager().Get(*item);
-        if (tmp.bo.type == BUYOUT_TYPE_NONE)
-            continue;
-        if (tmp.bo.source == BUYOUT_SOURCE_GAME)
+        tmp.bo = app_.buyout_manager().Get(*item);
+
+        if (!tmp.bo.IsPostable())
             continue;
         if (item->location().socketed())
             continue;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,24 +48,13 @@ double Util::AverageDamage(const std::string &s) {
 }
 
 void Util::PopulateBuyoutTypeComboBox(QComboBox *combobox) {
-    combobox->addItems(QStringList({"Ignore", "Buyout", "Fixed price", "No price"}));
+    combobox->addItems(QStringList({"[Ignore]", "Buyout", "Fixed price", "Current Offer", "No price", "[Inherit]"}));
+    combobox->setCurrentIndex(5);
 }
 
 void Util::PopulateBuyoutCurrencyComboBox(QComboBox *combobox) {
-    for (auto &currency : CurrencyAsString)
-        combobox->addItem(QString(currency.c_str()));
-}
-
-int Util::TagAsBuyoutType(const std::string &tag) {
-    return std::find(BuyoutTypeAsTag.begin(), BuyoutTypeAsTag.end(), tag) - BuyoutTypeAsTag.begin();
-}
-
-int Util::TagAsCurrency(const std::string &tag) {
-    return std::find(CurrencyAsTag.begin(), CurrencyAsTag.end(), tag) - CurrencyAsTag.begin();
-}
-
-int Util::TagAsBuyoutSource(const std::string &tag) {
-    return std::find(BuyoutSourceAsTag.begin(), BuyoutSourceAsTag.end(), tag) - BuyoutSourceAsTag.begin();
+    for (auto type : Currency::Types())
+        combobox->addItem(QString(Currency(type).AsString().c_str()));
 }
 
 static std::vector<std::string> width_strings = {
@@ -108,14 +97,6 @@ std::string Util::FindTextBetween(const std::string &page, const std::string &le
     if (first == std::string::npos || last == std::string::npos || first > last)
         return "";
     return page.substr(first + left.size(), last - first - left.size());
-}
-
-std::string Util::BuyoutAsText(const Buyout &bo) {
-    if (bo.type != BUYOUT_TYPE_NO_PRICE) {
-        return BuyoutTypeAsTag[bo.type] + " " + QString::number(bo.value).toStdString() + " " + CurrencyAsTag[bo.currency];
-    } else {
-        return BuyoutTypeAsTag[bo.type];
-    }
 }
 
 std::string Util::RapidjsonSerialize(const rapidjson::Value &val) {

--- a/src/util.h
+++ b/src/util.h
@@ -42,9 +42,6 @@ std::string Md5(const std::string &value);
 double AverageDamage(const std::string &s);
 void PopulateBuyoutTypeComboBox(QComboBox *combobox);
 void PopulateBuyoutCurrencyComboBox(QComboBox *combobox);
-int TagAsCurrency(const std::string &tag);
-int TagAsBuyoutType(const std::string &tag);
-int TagAsBuyoutSource(const std::string &tag);
 
 int TextWidth(TextWidthId id);
 


### PR DESCRIPTION
Submitting for code review if anyone has feedback or wants to check out the new inheritance stuff.  I'm not aware of any current bugs.  Some related issues included in these changes are #262, #214, #135, #99.

Lots of encapsulation work here to make a good part of code base
cleaner, safer and simpler.
- Promoted 'Currency' type to a class.
- Moved all string related, serialization functions and logical queries
into Buyout and Currency classes.
- Cleaned up tab inheritance
- Added new '[inherit]' and '[ignore]' states for buyout
- Buyouts now 'always' exist, removed Exists and Delete related
functions
- 'Default' buyouts are [inherit] type and are assumed if buyouts aren't
set

New features:
- Add Current Offer as buyout option
- Smarter logic that enables/disables buyout entry fields
- Now won't allow you to change anything on buyout entries you can't
modify