### PR TITLE
Fix last update issues with items in inherited state #280

### DIFF
--- a/src/buyoutmanager.cpp
+++ b/src/buyoutmanager.cpp
@@ -238,6 +238,26 @@ void BuyoutManager::CompressTabBuyouts() {
     }
 }
 
+void BuyoutManager::CompressItemBuyouts(const Items &items) {
+    // When items are moved between tabs or deleted their buyouts entries remain
+    // This function looks at buyouts and makes sure there is an associated item
+    // that exists
+    std::set<std::string> tmp;
+    for (auto const &item_sp: items) {
+        const Item & item= *item_sp;
+        tmp.insert(item.hash());
+    }
+
+    for (auto it = buyouts_.cbegin(); it != buyouts_.cend();) {
+        if (tmp.count(it->first) == 0) {
+
+            buyouts_.erase(it++);
+        } else {
+            ++it;
+        }
+    }
+}
+
 void BuyoutManager::SetRefreshChecked(const ItemLocation &loc, bool value) {
     save_needed_ = true;
     refresh_checked_[loc.GetUniqueHash()] = value;

--- a/src/buyoutmanager.h
+++ b/src/buyoutmanager.h
@@ -103,7 +103,7 @@ struct Buyout {
     bool IsValid() const;
     bool IsActive() const;
     bool IsInherited() const { return inherited || type == BUYOUT_TYPE_INHERIT; };
-    bool IsSavable() const { return IsValid() && !IsInherited(); };
+    bool IsSavable() const { return IsValid() && !(type == BUYOUT_TYPE_INHERIT); };
     bool IsPostable() const;
     bool IsPriced() const;
     bool IsGameSet() const;
@@ -147,6 +147,7 @@ public:
     void SetTab(const std::string &tab, const Buyout &buyout);
     Buyout GetTab(const std::string &tab) const;
     void CompressTabBuyouts();
+    void CompressItemBuyouts(const Items &items);
 
     void SetRefreshChecked(const ItemLocation &tab, bool value);
     bool GetRefreshChecked(const ItemLocation &tab) const;

--- a/src/itemsmanager.cpp
+++ b/src/itemsmanager.cpp
@@ -102,6 +102,8 @@ void ItemsManager::ApplyAutoItemBuyouts() {
             }
         }
     }
+
+    bo.CompressItemBuyouts(items_);
 }
 
 void ItemsManager::PropagateTabBuyouts() {
@@ -123,6 +125,7 @@ void ItemsManager::PropagateTabBuyouts() {
             if (tab_bo.IsActive()) {
                 // Any propagation from tab price to item price should include this bit set
                 tab_bo.inherited = true;
+                tab_bo.last_update = QDateTime::currentDateTime();
                 bo.Set(item, tab_bo);
             } else {
                 // This effectively 'clears' buyout by setting back to 'inherit' state.


### PR DESCRIPTION
- Need CompressItemBuyouts to remove stale buyouts, else buyouts have
'memory' between tabs and accumulate.
- Need to save inherited item state due to 'last_update' needing to be
preserved - so update IsSavable
- When adding new items don't propagate tabs 'last_update' time - start
fresh