### PR TITLE
Implement stable sort, fix issue #304

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -86,6 +86,10 @@ Item::Item(const rapidjson::Value &json) :
         }
     }
 
+    if (json.HasMember("id")) {
+        uid_ = json["id"].GetString();
+    }
+
     if (json.HasMember("note")) {
         note_ = json["note"].GetString();
     }
@@ -249,6 +253,8 @@ void Item::CalculateHash(const rapidjson::Value &json) {
     hash_ = Util::Md5(unique_new);
 }
 
-bool Item::operator<(const Item &other) const {
-    return hash_ < other.hash();
+bool Item::operator<(const Item &rhs) const {
+    std::string name = PrettyName();
+    std::string rhs_name = rhs.PrettyName();
+    return std::tie(name,uid_,hash_) < std::tie(rhs_name, rhs.uid_, hash_);
 }

--- a/src/item.h
+++ b/src/item.h
@@ -129,6 +129,7 @@ private:
     std::vector<ItemSocket> text_sockets_;
     std::string note_;
     ModTable mod_table_;
+    std::string uid_;
 };
 
 typedef std::vector<std::shared_ptr<Item>> Items;

--- a/src/itemlocation.cpp
+++ b/src/itemlocation.cpp
@@ -132,11 +132,9 @@ std::string ItemLocation::GetUniqueHash() const {
         return "character:" + character_;
 }
 
-bool ItemLocation::operator<(const ItemLocation &other) const {
-    if (type_ != other.type_)
-        return type_ < other.type_;
+bool ItemLocation::operator<(const ItemLocation &rhs) const {
     if (type_ == ItemLocationType::STASH)
-        return tab_id_ < other.tab_id_;
+        return std::tie(type_,tab_id_) < std::tie(rhs.type_,rhs.tab_id_);
     else
-        return character_ < other.character_;
+        return std::tie(type_,character_) < std::tie(rhs.type_,rhs.character_);
 }

--- a/src/itemsmanagerworker.cpp
+++ b/src/itemsmanagerworker.cpp
@@ -418,7 +418,7 @@ void ItemsManagerWorker::OnTabReceived(int request_id) {
         // item list as strings.
 
         std::sort(begin(items_), end(items_), [](const std::shared_ptr<Item> &a, const std::shared_ptr<Item> &b){
-            return b->location() < a->location();
+            return *a < *b;
         });
 
         QStringList tmp;


### PR DESCRIPTION
Sort was not stable for item, resulting in indeterminate ordering on every update.  Update to sort by name first (so items are in name order in display) then by universal id.

Clean up sort routine for location.