### PR TITLE
Add view selection options (by tab, by item)

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -41,6 +41,29 @@
             <item>
              <widget class="QLineEdit" name="buyoutValueLineEdit"/>
             </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>View:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="viewComboBox"/>
+            </item>
            </layout>
           </item>
          </layout>

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -8,7 +8,7 @@ Bucket::Bucket(const ItemLocation &location):
     location_(location)
 {}
 
-void Bucket::AddItem(const std::shared_ptr<Item> item) {
+void Bucket::AddItem(const std::shared_ptr<Item> & item) {
     items_.push_back(item);
 }
 

--- a/src/bucket.h
+++ b/src/bucket.h
@@ -11,10 +11,11 @@ class Bucket {
 public:
     Bucket();
     explicit Bucket(const ItemLocation &location);
-    void AddItem(const std::shared_ptr<Item> item);
+    void AddItem(const std::shared_ptr<Item> &item);
     const Items &items() const { return items_; }
     const ItemLocation &location() const { return location_; }
     void Sort(const Column &column, Qt::SortOrder order);
+
 private:
     Items items_;
     ItemLocation location_;

--- a/src/buyoutmanager.cpp
+++ b/src/buyoutmanager.cpp
@@ -81,6 +81,28 @@ const Currency::CurrencyTypeMap Currency::currency_type_as_tag_ = {
     {CURRENCY_MIRROR_OF_KALANDRA, "mirror"}
 };
 
+const Currency::CurrencyRankMap Currency::currency_type_as_rank_ = {
+    {CURRENCY_NONE, 0},
+    {CURRENCY_CHROMATIC_ORB, 1},
+    {CURRENCY_ORB_OF_ALTERATION, 2},
+    {CURRENCY_JEWELLERS_ORB, 3},
+    {CURRENCY_ORB_OF_CHANCE, 4},
+    {CURRENCY_CARTOGRAPHERS_CHISEL, 5},
+    {CURRENCY_PERANDUS_COIN, 6},
+    {CURRENCY_ORB_OF_FUSING, 7},
+    {CURRENCY_ORB_OF_ALCHEMY, 8},
+    {CURRENCY_BLESSED_ORB, 9},
+    {CURRENCY_ORB_OF_SCOURING, 10},
+    {CURRENCY_CHAOS_ORB, 11},
+    {CURRENCY_ORB_OF_REGRET, 12},
+    {CURRENCY_REGAL_ORB, 13},
+    {CURRENCY_VAAL_ORB, 14},
+    {CURRENCY_GCP, 15},
+    {CURRENCY_DIVINE_ORB, 16},
+    {CURRENCY_EXALTED_ORB, 17},
+    {CURRENCY_MIRROR_OF_KALANDRA, 18}
+};
+
 const std::string Buyout::buyout_type_error_;
 
 const Buyout::BuyoutTypeMap Buyout::buyout_type_as_tag_ = {
@@ -612,4 +634,9 @@ const std::string &Currency::AsTag() const {
         QLOG_WARN() << "No mapping from currency type: " << type << " to tag. This should never happen - please report.";
         return currency_type_error_;
     }
+}
+
+const int &Currency::AsRank() const
+{
+    return currency_type_as_rank_.at(type);
 }

--- a/src/buyoutmanager.h
+++ b/src/buyoutmanager.h
@@ -65,6 +65,7 @@ enum BuyoutSource {
 
 struct Currency {
     typedef std::map<CurrencyType, std::string> CurrencyTypeMap;
+    typedef std::map<CurrencyType, int> CurrencyRankMap;
 
     Currency() = default;
     Currency(CurrencyType in_type): type(in_type) { };
@@ -81,11 +82,13 @@ struct Currency {
 
     const std::string &AsString() const;
     const std::string &AsTag() const;
+    const int &AsRank() const;
 
 private:
     static const std::string currency_type_error_;
     static const CurrencyTypeMap currency_type_as_string_;
     static const CurrencyTypeMap currency_type_as_tag_;
+    static const CurrencyRankMap currency_type_as_rank_;
 };
 
 struct Buyout {

--- a/src/column.h
+++ b/src/column.h
@@ -34,6 +34,8 @@ public:
     virtual QColor color(const Item &item) const;
     virtual bool lt(const Item* lhs, const Item* rhs) const;
     virtual ~Column() {}
+private:
+    std::tuple<QVariant, QVariant, const Item&> multivalue(const Item *item) const;
 };
 
 class NameColumn : public Column {
@@ -95,7 +97,9 @@ public:
     std::string name() const;
     QVariant value(const Item &item) const;
     QColor color(const Item &item) const;
+    bool lt(const Item *lhs, const Item *rhs) const;
 private:
+    std::tuple<int, double, const Item&> multivalue(const Item *item) const;
     const BuyoutManager &bo_manager_;
 };
 
@@ -104,6 +108,7 @@ public:
     explicit DateColumn(const BuyoutManager &bo_manager);
     std::string name() const;
     QVariant value(const Item &item) const;
+    bool lt(const Item *lhs, const Item *rhs) const;
 private:
     const BuyoutManager &bo_manager_;
 };

--- a/src/items_model.h
+++ b/src/items_model.h
@@ -41,6 +41,9 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
     void sort(int column, Qt::SortOrder order);
     void sort();
+    Qt::SortOrder GetSortOrder() { return sort_order_;};
+    int GetSortColumn() { return sort_column_;};
+
 private:
     BuyoutManager &bo_manager_;
     const Search &search_;

--- a/src/search.h
+++ b/src/search.h
@@ -36,6 +36,12 @@ class QModelIndex;
 
 class Search {
 public:
+    enum ViewMode {
+        ByTab,
+        ByItem
+    };
+
+public:
     Search(BuyoutManager &bo, const std::string &caption, const std::vector<std::unique_ptr<Filter>> &filters, QTreeView *view);
     void FilterItems(const Items &items);
     void FromForm();
@@ -44,7 +50,7 @@ public:
     const std::string &caption() const { return caption_; }
     const Items &items() const { return items_; }
     const std::vector<std::unique_ptr<Column>> &columns() const { return columns_; }
-    const std::vector<std::unique_ptr<Bucket>> &buckets() const { return buckets_; }
+    const std::vector<std::unique_ptr<Bucket>> &buckets() const;
     QString GetCaption();
     int GetItemsCount();
     bool IsAnyFilterActive() const;
@@ -53,7 +59,8 @@ public:
     void RestoreViewProperties();
     void SaveViewProperties();
     ItemLocation GetTabLocation(const QModelIndex & index) const;
-
+    void SetViewMode(ViewMode mode);
+    int GetViewMode() { return current_mode_; };
 private:
     void UpdateItemCounts(const Items &items);
 
@@ -65,7 +72,9 @@ private:
     BuyoutManager &bo_manager_;
     std::unique_ptr<ItemsModel> model_;
     std::vector<std::unique_ptr<Bucket>> buckets_;
+    std::vector<std::unique_ptr<Bucket>> bucket_;
     uint unfiltered_item_count_{0};
     uint filtered_item_count_total_{0};
     QSet<QString> expanded_property_;
+    ViewMode current_mode_{ByTab};
 };


### PR DESCRIPTION
A new view can be chosen which allows sorting of all items at once.

Fixes a few bugs/issues with previous sorting implementation and preserves
column sorting selections per view tab.