### PR TITLE
Use QSplitter to manage mainwindow sections

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -6,26 +6,23 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>867</width>
-    <height>544</height>
+    <width>975</width>
+    <height>715</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Acquisition</string>
   </property>
   <widget class="QWidget" name="centralWidget">
-   <layout class="QGridLayout" name="gridLayout">
+   <layout class="QGridLayout" name="gridLayout_2">
     <item row="0" column="0">
      <layout class="QVBoxLayout" name="mainLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <property name="leftMargin">
-         <number>0</number>
+       <widget class="QSplitter" name="horizontalLayout_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item>
+        <widget class="QWidget" name="layoutWidget">
          <layout class="QVBoxLayout" name="itemListAndSearchFormLayout">
           <item>
            <widget class="QTreeView" name="treeView"/>
@@ -67,202 +64,228 @@
            </layout>
           </item>
          </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="itemLayout">
-          <item>
-           <widget class="QWidget" name="widget" native="true">
-            <property name="minimumSize">
-             <size>
-              <width>250</width>
-              <height>0</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="nameLabel">
-            <property name="text">
-             <string>Select an item</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="imageLabel"/>
-          </item>
-          <item>
-           <widget class="QTabWidget" name="itemInfoTypeTabs">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <widget class="QWidget" name="itemInfoTooltip">
-             <attribute name="title">
-              <string>Tooltip</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_2">
-              <item>
-               <widget class="QWidget" name="itemTooltipWidget" native="true">
-                <layout class="QVBoxLayout" name="itemTooltipLayout">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
+        </widget>
+        <widget class="QScrollArea" name="scrollArea">
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>349</width>
+            <height>638</height>
+           </rect>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>11</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <item row="0" column="0">
+            <layout class="QVBoxLayout" name="itemLayout">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="widget" native="true">
+               <property name="minimumSize">
+                <size>
+                 <width>250</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="nameLabel">
+               <property name="text">
+                <string>Select an item</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="imageLabel"/>
+             </item>
+             <item>
+              <widget class="QTabWidget" name="itemInfoTypeTabs">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="currentIndex">
+                <number>0</number>
+               </property>
+               <widget class="QWidget" name="itemInfoTooltip">
+                <attribute name="title">
+                 <string>Tooltip</string>
+                </attribute>
+                <layout class="QVBoxLayout" name="verticalLayout_2">
                  <item>
-                  <layout class="QHBoxLayout" name="itemNameLayout">
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="itemHeaderLeft">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QWidget" name="itemNameContainerWidget" native="true">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <layout class="QVBoxLayout" name="itemNameContainer">
+                  <widget class="QWidget" name="itemTooltipWidget" native="true">
+                   <layout class="QVBoxLayout" name="itemTooltipLayout">
+                    <property name="spacing">
+                     <number>0</number>
+                    </property>
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <layout class="QHBoxLayout" name="itemNameLayout">
                       <property name="spacing">
-                       <number>0</number>
-                      </property>
-                      <property name="leftMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="topMargin">
-                       <number>0</number>
-                      </property>
-                      <property name="rightMargin">
                        <number>0</number>
                       </property>
                       <property name="bottomMargin">
                        <number>0</number>
                       </property>
                       <item>
-                       <widget class="QLabel" name="itemNameFirstLine">
+                       <widget class="QLabel" name="itemHeaderLeft">
                         <property name="text">
                          <string/>
                         </property>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QLabel" name="itemNameSecondLine">
+                       <widget class="QWidget" name="itemNameContainerWidget" native="true">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <layout class="QVBoxLayout" name="itemNameContainer">
+                         <property name="spacing">
+                          <number>0</number>
+                         </property>
+                         <property name="leftMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="topMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="rightMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <item>
+                          <widget class="QLabel" name="itemNameFirstLine">
+                           <property name="text">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QLabel" name="itemNameSecondLine">
+                           <property name="text">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLabel" name="itemHeaderRight">
                         <property name="text">
                          <string/>
                         </property>
                        </widget>
                       </item>
                      </layout>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="itemHeaderRight">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="propertiesLabel">
+                      <property name="maximumSize">
+                       <size>
+                        <width>16777215</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
                  </item>
                  <item>
-                  <widget class="QLabel" name="propertiesLabel">
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
+                  <widget class="QPushButton" name="uploadTooltipButton">
+                   <property name="text">
+                    <string>Upload to imgur</string>
                    </property>
                   </widget>
                  </item>
                 </layout>
                </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="uploadTooltipButton">
-                <property name="text">
-                 <string>Upload to imgur</string>
-                </property>
+               <widget class="QWidget" name="itemInfoText">
+                <attribute name="title">
+                 <string>Text</string>
+                </attribute>
+                <layout class="QVBoxLayout" name="verticalLayout">
+                 <item>
+                  <widget class="QLabel" name="itemTextTooltip">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="itemInfoText">
-             <attribute name="title">
-              <string>Text</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout">
-              <item>
-               <widget class="QLabel" name="itemTextTooltip">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
+               <widget class="QWidget" name="tab">
+                <attribute name="title">
+                 <string>Hide</string>
+                </attribute>
                </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab">
-             <attribute name="title">
-              <string>Hide</string>
-             </attribute>
-            </widget>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QLabel" name="locationLabel"/>
-          </item>
-          <item>
-           <widget class="QLabel" name="minimapLabel"/>
-          </item>
-         </layout>
-        </item>
-       </layout>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="locationLabel"/>
+             </item>
+             <item>
+              <widget class="QLabel" name="minimapLabel"/>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </widget>
       </item>
      </layout>
     </item>
@@ -273,7 +296,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>867</width>
+     <width>975</width>
      <height>26</height>
     </rect>
    </property>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -178,12 +178,15 @@ void MainWindow::InitializeUi() {
     scroll_area->setMinimumWidth(150); // TODO(xyz): remove magic numbers
     scroll_area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
+    ui->scrollArea->setFrameShape(QFrame::NoFrame);
+    ui->scrollArea->setWidgetResizable(true);
+
     ui->horizontalLayout_2->insertWidget(0, scroll_area);
     search_form_container->show();
 
-    ui->horizontalLayout_2->setStretchFactor(scroll_area, 1);
-    ui->horizontalLayout_2->setStretchFactor(ui->itemListAndSearchFormLayout, 4);
-    ui->horizontalLayout_2->setStretchFactor(ui->itemLayout, 2);
+    ui->horizontalLayout_2->setStretchFactor(0, 2);
+    ui->horizontalLayout_2->setStretchFactor(1, 5);
+    ui->horizontalLayout_2->setStretchFactor(2, 0);
 
     ui->treeView->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeView->setSelectionMode(QAbstractItemView::ExtendedSelection);
@@ -237,11 +240,6 @@ void MainWindow::InitializeUi() {
         tabs->widget(idx)->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
         tabs->widget(idx)->resize(tabs->widget(idx)->minimumSizeHint());
         tabs->widget(idx)->adjustSize();
-
-        if (idx == 0)
-            ui->horizontalLayout_2->setStretchFactor(ui->itemLayout, 2);
-        else
-            ui->horizontalLayout_2->setStretchFactor(ui->itemLayout, 1);
 
         app_->data().SetInt("preferred_tooltip_type", idx);
     });


### PR DESCRIPTION
This is proposal to fix #322 and #181, basically just let user manage section sizes using QSplitter and don't try to get fancy.  Also wraps item view stuff in QScrollArea.

Positives:

1. No suprising section resizes as totally user controlled
2. Users can fully hide both left and right sections by dragging QSplitter
3. User can expand left section to show two columns if desired

Negatives:
1. Users will generally need to resize right section at least once to remove horizontal scroll bar for really wide items.

I did actually try to play around with resizing right section automatically but couldn't get it to work reliably due to not understanding the resizing policy stuff well enough. It also doesn't really fit with splitter idea as combining auto-resize with user-resize doesn't really work.
