### PR TITLE
Better handle no chars in a league condition

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -206,6 +206,14 @@ void MainWindow::InitializeUi() {
         context_menu_.popup(ui->treeView->viewport()->mapToGlobal(pos));
     });
 
+    refresh_button_.setStyleSheet("color: blue; font-weight: bold;");
+    refresh_button_.setFlat(true);
+    refresh_button_.hide();
+    statusBar()->addPermanentWidget(&refresh_button_);
+    connect(&refresh_button_, &QPushButton::clicked, [=](){
+        on_actionRefresh_selected_triggered();
+    });
+
     statusBar()->addPermanentWidget(&online_label_);
     UpdateOnlineGui();
 
@@ -358,6 +366,14 @@ void MainWindow::OnStatusUpdate(const CurrentStatusUpdate &status) {
     QString title;
     bool need_progress = false;
     switch (status.state) {
+    case ProgramState::CharactersReceived:
+        if (status.total == 0) {
+            refresh_button_.setText("No characters detected yet in this league, click to refresh");
+            refresh_button_.show();
+        } else {
+            refresh_button_.hide();
+        }
+        break;
     case ProgramState::ItemsReceive:
     case ProgramState::ItemsPaused:
         title = QString("Receiving stash data, %1/%2 [%3 from cache]").arg(status.progress).arg(status.total).arg(status.cached);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -62,6 +62,8 @@ enum class TreeState {
 };
 
 enum class ProgramState {
+    Unknown,
+    CharactersReceived,
     ItemsReceive,
     ItemsPaused,
     ItemsCompleted,
@@ -71,7 +73,7 @@ enum class ProgramState {
 
 struct CurrentStatusUpdate {
     ProgramState state;
-    int progress, total, cached;
+    int progress{}, total{}, cached{};
 };
 
 class MainWindow : public QMainWindow {
@@ -153,6 +155,7 @@ private:
     QMenu context_menu_;
     UpdateChecker update_checker_;
     QPushButton update_button_;
+    QPushButton refresh_button_;
     AutoOnline auto_online_;
     QLabel online_label_;
     QNetworkAccessManager *network_manager_;


### PR DESCRIPTION
This should take care of corner cases around when users start acquisition and possibly no chars in a league yet.

It will notify users that no chars exist and allow them to click to refresh.