### PR TITLE
Auto update checked tabs properly

### DIFF
--- a/src/itemsmanager.cpp
+++ b/src/itemsmanager.cpp
@@ -172,7 +172,7 @@ void ItemsManager::SetAutoUpdateInterval(int minutes) {
 }
 
 void ItemsManager::OnAutoRefreshTimer() {
-    Update(TabSelection::Selected);
+    Update(TabSelection::Checked);
 }
 
 void ItemsManager::MigrateBuyouts() {


### PR DESCRIPTION
Resolves #397.  

This is worthy of a new release as a basic mechanism was broken.  Maybe we should wait a few days to see if any other issues are reported though.