### PR TITLE
Migrate to WebEngine from WebKit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,17 @@ matrix:
       env: COMPILER=clang++-3.6
 
 before_install:
- - sudo add-apt-repository --yes ppa:beineri/opt-qt542-trusty
+ - sudo add-apt-repository --yes ppa:beineri/opt-qt562-trusty
  - sudo apt-get update -qq
 
 install:
- - sudo apt-get install qt54base qt54webkit valgrind
+ - sudo apt-get install qt56base qt56webengine valgrind
 
 script:
  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi
- - . /opt/qt54/bin/qt54-env.sh
+ - . /opt/qt56/bin/qt56-env.sh
  - qmake QMAKE_CC=$CC QMAKE_CXX=$CXX QMAKE_CXXFLAGS+="-g" QMAKE_CFLAGS+="-g" QMAKE_LINK=g++-4.9
  - make -j2
+ - glxinfo
  - valgrind ./acquisition --test -platform offscreen

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,16 @@ matrix:
       env: COMPILER=clang++-3.6
 
 before_install:
- - sudo add-apt-repository --yes ppa:beineri/opt-qt562-trusty
+ - sudo add-apt-repository --yes ppa:beineri/opt-qt591-trusty
  - sudo apt-get update -qq
 
 install:
- - sudo apt-get install qt56base qt56webengine valgrind
+ - sudo apt-get install qt59base qt59webengine valgrind
 
 script:
  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi
- - . /opt/qt56/bin/qt56-env.sh
+ - . /opt/qt59/bin/qt59-env.sh
  - qmake QMAKE_CC=$CC QMAKE_CXX=$CXX QMAKE_CXXFLAGS+="-g" QMAKE_CFLAGS+="-g" QMAKE_LINK=g++-4.9 CONFIG+=nowebengine
  - make -j2
  - valgrind --run-libc-freeres=no ./acquisition --test -platform offscreen

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ script:
  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.6" CC="clang-3.6"; fi
  - . /opt/qt56/bin/qt56-env.sh
- - qmake QMAKE_CC=$CC QMAKE_CXX=$CXX QMAKE_CXXFLAGS+="-g" QMAKE_CFLAGS+="-g" QMAKE_LINK=g++-4.9
+ - qmake QMAKE_CC=$CC QMAKE_CXX=$CXX QMAKE_CXXFLAGS+="-g" QMAKE_CFLAGS+="-g" QMAKE_LINK=g++-4.9 CONFIG+=nowebengine
  - make -j2
- - glxinfo
- - valgrind ./acquisition --test -platform offscreen
+ - valgrind --run-libc-freeres=no ./acquisition --test -platform offscreen

--- a/acquisition.pro
+++ b/acquisition.pro
@@ -1,7 +1,7 @@
 TARGET = acquisition
 TEMPLATE = app
 
-QT += core gui network webenginewidgets testlib
+QT += core gui network testlib
 
 win32 {
     QT += winextras
@@ -11,6 +11,12 @@ win32 {
 unix {
     LIBS += -ldl
     QMAKE_CXXFLAGS += -Wno-inconsistent-missing-override
+}
+
+nowebengine {
+  DEFINES += NO_WEBENGINE
+} else {
+  QT += webenginewidgets
 }
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

--- a/acquisition.pro
+++ b/acquisition.pro
@@ -1,7 +1,7 @@
 TARGET = acquisition
 TEMPLATE = app
 
-QT += core gui network webkitwidgets testlib
+QT += core gui network webenginewidgets testlib
 
 win32 {
     QT += winextras

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
-os: unstable
+image: Visual Studio 2017
 
 install:
   - git submodule update --init deps/boost-header-only
 
 before_build:
-  - C:\Qt\5.6\msvc2013\bin\qmake.exe -tp vc
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
+  - C:\Qt\5.9.1\msvc2017_64\bin\qmake.exe -tp vc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,4 +4,4 @@ install:
   - git submodule update --init deps/boost-header-only
 
 before_build:
-  - C:\Qt\5.4\msvc2013_opengl\bin\qmake.exe -tp vc
+  - C:\Qt\5.6\msvc2013\bin\qmake.exe -tp vc

--- a/forms/steamlogindialog.ui
+++ b/forms/steamlogindialog.ui
@@ -13,25 +13,8 @@
   <property name="windowTitle">
    <string>Steam login</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QWebEngineView" name="webView" native="true">
-     <property name="url" stdset="0">
-      <url>
-       <string>about:blank</string>
-      </url>
-     </property>
-    </widget>
-   </item>
-  </layout>
+  <layout class="QVBoxLayout" name="verticalLayout"/>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QWebEngineView</class>
-   <extends>QWidget</extends>
-   <header>QtWebEngineWidgets/QWebEngineView</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/forms/steamlogindialog.ui
+++ b/forms/steamlogindialog.ui
@@ -15,8 +15,8 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWebView" name="webView">
-     <property name="url">
+    <widget class="QWebEngineView" name="webView" native="true">
+     <property name="url" stdset="0">
       <url>
        <string>about:blank</string>
       </url>
@@ -27,9 +27,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QWebView</class>
+   <class>QWebEngineView</class>
    <extends>QWidget</extends>
-   <header>QtWebKitWidgets/QWebView</header>
+   <header>QtWebEngineWidgets/QWebEngineView</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/logindialog.cpp
+++ b/src/logindialog.cpp
@@ -32,8 +32,10 @@
 #include <QSettings>
 #include <QUrl>
 #include <QUrlQuery>
+#ifndef NO_WEBENGINE
 #include <QWebEngineProfile>
 #include <QWebEngineCookieStore>
+#endif
 #include <iostream>
 #include "QsLog.h"
 
@@ -293,9 +295,11 @@ void LoginDialog::SaveSettings() {
     // By default WebEngine stores cookies like a normal browser and steamMachineAuth
     // cookie does not naturally expire.  Without this cookie the user will be required to
     // re-verify access through e-mail.
+#ifndef NO_WEBENGINE
     if (!settings.value("remember_me_checked").toBool()) {
         QWebEngineProfile::defaultProfile()->cookieStore()->deleteAllCookies();
     }
+#endif
 }
 
 void LoginDialog::DisplayError(const QString &error, bool disable_login) {

--- a/src/logindialog.cpp
+++ b/src/logindialog.cpp
@@ -32,6 +32,8 @@
 #include <QSettings>
 #include <QUrl>
 #include <QUrlQuery>
+#include <QWebEngineProfile>
+#include <QWebEngineCookieStore>
 #include <iostream>
 #include "QsLog.h"
 
@@ -282,6 +284,18 @@ void LoginDialog::SaveSettings() {
     }
     settings.setValue("remember_me_checked", ui->rembmeCheckBox->isChecked() && !session_id_.isEmpty());
     settings.setValue("use_system_proxy_checked", ui->proxyCheckBox->isChecked());
+
+    // Clear any saved cookies (steamMachineAuth in particular) if user doesn't want
+    // us to remember login info.
+    //
+    // For details see: https://dev.doctormckay.com/topic/365-cookies/
+    //
+    // By default WebEngine stores cookies like a normal browser and steamMachineAuth
+    // cookie does not naturally expire.  Without this cookie the user will be required to
+    // re-verify access through e-mail.
+    if (!settings.value("remember_me_checked").toBool()) {
+        QWebEngineProfile::defaultProfile()->cookieStore()->deleteAllCookies();
+    }
 }
 
 void LoginDialog::DisplayError(const QString &error, bool disable_login) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
     logger.addDestination(debugDestination);
     logger.addDestination(fileDestination);
 
-    QLOG_DEBUG() << "--------------------------------------------------------------------------------";
+    QLOG_DEBUG() << "-------------------------------------------------------------------------------";
     QLOG_DEBUG() << "Built with Qt" << QT_VERSION_STR << "running on" << qVersion();
 
     LoginDialog login(std::make_unique<Application>());

--- a/src/replytimeout.h
+++ b/src/replytimeout.h
@@ -14,4 +14,4 @@ private slots:
 
 const int kEditThreadTimeout = 300000; // 5 minutes, pathofexile.com can be very slow
 const int kImgurUploadTimeout = 10000; // 10s
-const int kPoeApiTimeout = 3000;
+const int kPoeApiTimeout = 10000;

--- a/src/steamlogindialog.cpp
+++ b/src/steamlogindialog.cpp
@@ -22,20 +22,45 @@
 
 #include <QCloseEvent>
 #include "QsLog.h"
+#include <memory>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QWebEngineProfile>
+#include <QWebEngineCookieStore>
 #include <QNetworkCookie>
 #include <QNetworkCookieJar>
 #include <QNetworkRequest>
 #include <QUrlQuery>
 #include <QFile>
-#include <QSettings>
 
 #include "filesystem.h"
+
+extern const char* POE_COOKIE_NAME;
 
 SteamLoginDialog::SteamLoginDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::SteamLoginDialog)
 {
     ui->setupUi(this);
+
+    connect(ui->webView, &QWebEngineView::loadProgress, [this](int progress) {
+        if (progress > 0 && progress < 100) {
+            setWindowTitle(QString("Loading...  (%2%)").arg(progress));
+        } else {
+            setWindowTitle(ui->webView->title());
+        }
+    });
+
+    connect(QWebEngineProfile::defaultProfile()->cookieStore(),
+            &QWebEngineCookieStore::cookieAdded, [this](const QNetworkCookie& cookie) {
+        if (cookie.name() == POE_COOKIE_NAME) {
+            QString session_id = QString(cookie.value());
+            ui->webView->stop();
+            emit CookieReceived(session_id);
+            completed_ = true;
+            close();
+        }
+    });
 }
 
 SteamLoginDialog::~SteamLoginDialog() {
@@ -50,95 +75,17 @@ void SteamLoginDialog::closeEvent(QCloseEvent *e) {
 
 void SteamLoginDialog::Init() {
     completed_ = false;
-    disconnect(this, SLOT(OnLoadFinished()));
-    // clear all previous cookies
-    ui->webView->page()->networkAccessManager()->setCookieJar(new QNetworkCookieJar());
-    ui->webView->setContent("Loading, please wait...");
 
     QByteArray data("x=0&y=0");
     QNetworkRequest request(QUrl("https://www.pathofexile.com/login/steam"));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+    QNetworkReply *reply = network_manager_.post(request, data);
 
-    ui->webView->load(request, QNetworkAccessManager::PostOperation, data);
-
-    settings_path_ = Filesystem::UserDir() + "/settings.ini";
-    SetSteamCookie(LoadSteamCookie());
-
-    connect(ui->webView, SIGNAL(loadFinished(bool)), this, SLOT(OnLoadFinished()));
-}
-
-extern const char* POE_COOKIE_NAME;
-
-void SteamLoginDialog::OnLoadFinished() {
-    if (completed_)
-        return;
-    QString url = ui->webView->url().toString();
-    if (url.startsWith("https://www.pathofexile.com/")) {
-        QNetworkCookieJar *cookie_jar = ui->webView->page()->networkAccessManager()->cookieJar();
-        QList<QNetworkCookie> cookies = cookie_jar->cookiesForUrl(QUrl("https://www.pathofexile.com/"));
-        QString session_id;
-
-        QNetworkCookieJar *steam_jar = ui->webView->page()->networkAccessManager()->cookieJar();
-        QList<QNetworkCookie> steam_cookies = steam_jar->cookiesForUrl(QUrl("https://steamcommunity.com/openid/"));
-
-        QSettings settings(settings_path_.c_str(), QSettings::IniFormat);
-        bool rembme = settings.value("remember_me_checked").toBool();
-
-        for(auto cookie: steam_cookies) {
-            if(cookie.name().startsWith("steamMachineAuth")) {
-                if(rembme && !settings.contains("steamMachineAuth")) {
-                    SaveSteamCookie(cookie);
-                } else if(rembme && cookie != LoadSteamCookie()) {
-                    SaveSteamCookie(cookie);
-                }
-            }
-        }
-
-        for (auto &cookie : cookies)
-            if (cookie.name() == POE_COOKIE_NAME)
-                session_id = QString(cookie.value());
-        ui->webView->stop();
-
-        completed_ = true;
-        emit CookieReceived(session_id);
-
-        close();
-    }
-}
-
-void SteamLoginDialog::SetSteamCookie(QNetworkCookie steam_cookie) {
-    // Sets a cookie on the steamcommunity.com url so that users don't have to
-    // do the email verification every time that they sign in on with steam.
-
-    QList<QNetworkCookie> cookie;
-    cookie << steam_cookie;
-
-    QNetworkCookieJar *steam_community = ui->webView->page()->networkAccessManager()->cookieJar();
-    steam_community->setCookiesFromUrl(cookie, QUrl("https://steamcommunity.com/openid/"));
-}
-
-void SteamLoginDialog::SaveSteamCookie(QNetworkCookie cookie) {
-    // Saves the file to a file located in the acquisition directory.
-
-    QSettings settings(settings_path_.c_str(), QSettings::IniFormat);
-    settings.setValue("steam-id", cookie.name().remove(0, 16));
-    settings.setValue(cookie.name(), cookie.value());
-}
-
-QNetworkCookie SteamLoginDialog::LoadSteamCookie() {
-    // Function to load the cookie from a file located in the acquisition
-    // directory.
-
-    QString cookie_name = "steamMachineAuth";
-    QString cookie_value;
-    QSettings settings(settings_path_.c_str(), QSettings::IniFormat);
-
-    cookie_name.append(settings.value("steam-id").toString());
-    cookie_value = settings.value(cookie_name).toString();
-
-    QNetworkCookie cookie(cookie_name.toUtf8(), cookie_value.toUtf8());
-    cookie.setPath("/");
-    cookie.setDomain("steamcommunity.com");
-
-    return cookie;
+    auto conn = std::shared_ptr<QMetaObject::Connection>(new QMetaObject::Connection());
+    *conn = connect(reply, &QNetworkReply::finished, [this, reply, conn] {
+        auto attr = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
+        ui->webView->load(attr.toUrl());
+        reply->deleteLater();
+        disconnect(*conn);
+    });
 }

--- a/src/steamlogindialog.h
+++ b/src/steamlogindialog.h
@@ -21,6 +21,8 @@
 
 #include <QDialog>
 #include <QNetworkCookie>
+#include <QNetworkAccessManager>
+#include <memory>
 
 namespace Ui {
 class SteamLoginDialog;
@@ -42,11 +44,6 @@ protected:
 private:
     Ui::SteamLoginDialog *ui;
     bool completed_;
-    void SetSteamCookie(QNetworkCookie);
-    void SaveSteamCookie(QNetworkCookie);
-    QNetworkCookie LoadSteamCookie();
 
-    std::string settings_path_;
-private slots:
-    void OnLoadFinished();
+    QNetworkAccessManager network_manager_;
 };

--- a/src/steamlogindialog.h
+++ b/src/steamlogindialog.h
@@ -23,6 +23,9 @@
 #include <QNetworkCookie>
 #include <QNetworkAccessManager>
 #include <memory>
+#ifndef NO_WEBENGINE
+#include <QWebEngineView>
+#endif
 
 namespace Ui {
 class SteamLoginDialog;
@@ -44,6 +47,8 @@ protected:
 private:
     Ui::SteamLoginDialog *ui;
     bool completed_;
-
+#ifndef NO_WEBENGINE
+    QWebEngineView* webView;
+#endif
     QNetworkAccessManager network_manager_;
 };


### PR DESCRIPTION
Includes update to QT 5.6.2 which is required for grabbing cookies with WebEngine.
