### PR TITLE
remove_mtx_support

### DIFF
--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -401,10 +401,6 @@ bool BooleanFilter::Matches(const std::shared_ptr<Item> & /* item */, FilterData
     return true;
 }
 
-bool MTXFilter::Matches(const std::shared_ptr<Item> &item, FilterData *data) {
-    return !data->checked || item->has_mtx();
-}
-
 bool AltartFilter::Matches(const std::shared_ptr<Item> &item, FilterData *data) {
     static std::vector<std::string> altart = {
         // season 1

--- a/src/filters.h
+++ b/src/filters.h
@@ -236,13 +236,6 @@ protected:
     std::string property_, caption_;
 };
 
-class MTXFilter : public BooleanFilter {
-public:
-    MTXFilter(QLayout *parent, std::string property, std::string caption):
-        BooleanFilter(parent, property, caption) {}
-    bool Matches(const std::shared_ptr<Item> &item, FilterData *data);
-};
-
 class AltartFilter : public BooleanFilter {
 public:
     AltartFilter(QLayout *parent, std::string property, std::string caption):

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -92,7 +92,6 @@ Item::Item(const rapidjson::Value &json) :
     links_cnt_(0),
     sockets_({ 0, 0, 0, 0 }),
     json_(Util::RapidjsonSerialize(json)),
-    has_mtx_(false),
     ilvl_(0)
 {
     if (json.HasMember("name") && json["name"].IsString())
@@ -271,8 +270,6 @@ Item::Item(const rapidjson::Value &json) :
             count_ = std::stoi(size);
         }
     }
-
-    has_mtx_ = json.HasMember("cosmeticMods");
 
     if (json.HasMember("ilvl") && json["ilvl"].IsInt())
         ilvl_ = json["ilvl"].GetInt();

--- a/src/item.h
+++ b/src/item.h
@@ -98,7 +98,6 @@ public:
     const std::vector<std::string>& category_vector() const { return category_vector_; };
     uint talisman_tier() const { return talisman_tier_; };
     int count() const { return count_; };
-    bool has_mtx() const { return has_mtx_; }
     const ModTable &mod_table() const { return mod_table_; }
     int ilvl() const { return ilvl_; }
     bool operator<(const Item &other) const;
@@ -131,7 +130,6 @@ private:
     std::map<std::string, int> requirements_;
     std::string json_;
     int count_;
-    bool has_mtx_;
     int ilvl_;
     std::vector<ItemProperty> text_properties_;
     std::vector<ItemRequirement> text_requirements_;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -597,7 +597,6 @@ void MainWindow::InitializeSearchForm() {
         std::make_unique<SimplePropertyFilter>(misc_layout, "Level"),
         std::make_unique<SimplePropertyFilter>(misc_layout, "Map Tier"),
         std::make_unique<ItemlevelFilter>(misc_layout, "ilvl"),
-        std::make_unique<MTXFilter>(misc_flags_layout, "", "MTX"),
         std::make_unique<AltartFilter>(misc_flags_layout, "", "Alt. art"),
         std::make_unique<PricedFilter>(misc_flags_layout, "", "Priced", app_->buyout_manager()),
         std::make_unique<ModsFilter>(mods_layout)


### PR DESCRIPTION
MTX no long appear via the API since POE (pre-)3.0 Fall of Oriath, mid 2017.

Removed items' MTX boolean property, getter method, filter wrapper and search UI field.