### PR TITLE
Improve categories

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -261,10 +261,54 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QPushButton" name="uploadTooltipButton">
-                   <property name="text">
-                    <string>Upload to imgur</string>
+                  <widget class="QWidget" name="itemButtonsWidget" native="true">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
                    </property>
+                   <layout class="QVBoxLayout" name="itemButtonsLayout">
+                    <property name="spacing">
+                     <number>5</number>
+                    </property>
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QPushButton" name="uploadTooltipButton">
+                      <property name="text">
+                       <string>Upload to imgur</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="Line" name="pobButtonLine">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="pobTooltipButton">
+                      <property name="enabled">
+                       <bool>false</bool>
+                      </property>
+                      <property name="text">
+                       <string>Copy for Path of Building</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </widget>
                  </item>
                 </layout>

--- a/src/autoonline.cpp
+++ b/src/autoonline.cpp
@@ -53,7 +53,7 @@ bool is_poe_running_locally() {
 
     pe32.dwSize = sizeof(PROCESSENTRY32);
 
-    if(!Process32First(hProcessSnap, &pe32)) {
+    if (!Process32First(hProcessSnap, &pe32)) {
         QLOG_ERROR() << "Process32First";
         CloseHandle(hProcessSnap);
         return false;
@@ -114,7 +114,7 @@ void AutoOnline::SendOnlineUpdate(bool online) {
     // online: true  -> Go online
     // online: false -> Go offline
     std::string url = url_;
-    if(!online) {
+    if (!online) {
         url += "/offline";
     }
     QNetworkRequest request(QUrl(url.c_str()));
@@ -125,7 +125,7 @@ void AutoOnline::SendOnlineUpdate(bool online) {
 
 void AutoOnline::Check() {
     bool running = is_poe_running_locally();
-    if(IsRemoteScriptSet()){
+    if (IsRemoteScriptSet()){
         running = is_poe_running_remotely(process_script_);
     } else {
         running = is_poe_running_locally();

--- a/src/buyoutmanager.cpp
+++ b/src/buyoutmanager.cpp
@@ -255,7 +255,7 @@ void BuyoutManager::CompressTabBuyouts() {
         tmp.insert(loc.GetUniqueHash());
 
     for (auto it = tab_buyouts_.begin(), ite = tab_buyouts_.end(); it != ite;) {
-        if(tmp.count(it->first) == 0) {
+        if (tmp.count(it->first) == 0) {
             save_needed_ = true;
             it = tab_buyouts_.erase(it);
         } else {

--- a/src/currencymanager.cpp
+++ b/src/currencymanager.cpp
@@ -179,7 +179,7 @@ void CurrencyManager::Deserialize(const std::string &data, std::vector<std::shar
         auto &object = itr->value;
         Currency curr = Currency::FromTag(object["currency"].GetString());
         for (auto &item : *currencies) {
-            if(item->currency == curr) {
+            if (item->currency == curr) {
                 item = std::make_shared<CurrencyItem>(object["count"].GetDouble(), curr,
                         object["chaos_ratio"].GetDouble(), object["exalt_ratio"].GetDouble());
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -30,25 +30,6 @@
 #include "porting.h"
 #include "itemlocation.h"
 
-const std::array<Item::CategoryReplaceMap, Item::k_CategoryLevels> Item::replace_map_ = {
-    // Category hierarchy 0 replacement map
-    Item::CategoryReplaceMap(),
-    // Category hierarchy 1 replacement map
-    Item::CategoryReplaceMap({{"BodyArmours", "Body"},
-                              {"VaalGems", "Vaal"},
-                              {"AtlasMaps", "Atlas"},
-                              {"act4maps", "Act4"},
-                              {"OneHandWeapons", "OneHand"},
-                              {"TwoHandWeapons", "TwoHand"}}),
-    // Category hierarchy 2 replacement map
-    Item::CategoryReplaceMap({{"OneHandAxes", "Axes"},
-                              {"OneHandMaces", "Maces"},
-                              {"OneHandSwords", "Swords"},
-                              {"TwoHandAxes", "Axes"},
-                              {"TwoHandMaces", "Maces"},
-                              {"TwoHandSwords", "Swords"}})
-};
-
 const std::vector<std::string> ITEM_MOD_TYPES = {
     "implicitMods", "enchantMods", "explicitMods", "craftedMods"
 };
@@ -87,8 +68,7 @@ Item::Item(const rapidjson::Value &json) :
     corrupted_(false),
     crafted_(false),
     enchanted_(false),
-    shaper_(false),
-    elder_(false),
+    baseType_(BASE_NORMAL),
     w_(0),
     h_(0),
     frameType_(0),
@@ -114,9 +94,9 @@ Item::Item(const rapidjson::Value &json) :
         enchanted_ = true;
 	
     if (json.HasMember("shaper") && json["shaper"].IsBool())
-        shaper_ = json["shaper"].GetBool();
+        baseType_ = BASE_SHAPER;
     if (json.HasMember("elder") && json["elder"].IsBool())
-        elder_ = json["elder"].GetBool();
+        baseType_ = BASE_ELDER;
 
     if (json.HasMember("w") && json["w"].IsInt())
         w_ = json["w"].GetInt();
@@ -144,22 +124,7 @@ Item::Item(const rapidjson::Value &json) :
     // to handle elsewhere
     boost::replace_last(icon_, "quad=1", "quad=0");
 
-    // Derive item type 'category' hierarchy from icon path.
-    std::smatch sm;
-    if (std::regex_search(icon_, sm, std::regex("Art/.*?/(.*)/"))) {
-        std::string match = sm.str(1);
-        boost::split(category_vector_,match,boost::is_any_of("/"));
-        //Compress terms with redundant identifiers
-        //Weapons.OneHandWeapons.OneHandMaces -> Weapons.OneHand.Maces
-        size_t min = std::min(category_vector_.size(), replace_map_.size());
-        for (size_t i = 1; i < min; i++) {
-            auto it = replace_map_[i].find(category_vector_[i]);
-            if (it != replace_map_[i].end())
-                category_vector_[i] = it->second;
-        }
-        category_ = boost::join(category_vector_, ".");
-        boost::to_lower(category_);
-    }
+    CalculateCategories(json);
 
     if (json.HasMember("talismanTier") && json["talismanTier"].IsUint()) {
        talisman_tier_ = json["talismanTier"].GetUint();
@@ -179,7 +144,7 @@ Item::Item(const rapidjson::Value &json) :
             if (!prop.HasMember("name") || !prop["name"].IsString() || !prop.HasMember("values") || !prop["values"].IsArray())
                 continue;
             std::string name = prop["name"].GetString();
-            if (name == "Map Level")
+            if (name == "Map Level")    // I can find no example of this, should it be "Map Tier"?
                 name = "Level";
             if (name == "Elemental Damage") {
                 for (auto value_it = prop["values"].Begin(); value_it != prop["values"].End(); ++value_it) {
@@ -297,6 +262,134 @@ std::string Item::PrettyName() const {
     return typeLine_;
 }
 
+void Item::CalculateCategories(const rapidjson::Value &json) {
+    category_ = "";
+    if (json.HasMember("category") && json["category"].IsObject()) {
+        // This object contains a single array who's name is the item's category. The array may contain the item's sub-category
+        rapidjson::Value::ConstMemberIterator itr = json["category"].MemberBegin();
+        category_ = itr->name.GetString();
+        Util::Capitalise(category_);
+
+        if(category_ == "Cards") {
+            category_ = "Divination cards";
+        }
+
+        category_vector_.push_back(category_);
+        if( itr->value.IsArray() && !itr->value.Empty() ) {
+            // Handle sub-categories
+
+            if(category_ == "Accessories") {    // Elevate accessories sub-categories to their own top level categories
+                category_vector_.pop_back();
+                // If amulet and .HasMember("talismanTier") (which is also checked after CalculateCategories()), add Talisman sub-category?
+            }
+
+            /*
+            If Armour.Chests, rename Armour.BodyArmour?
+            If Flasks, use Base64 encoded JSON within icon path to determine sub-category?
+            */
+
+            category_ = itr->value[0].GetString();
+            Util::Capitalise(category_);
+
+            if(category_ == "Activegem") {
+                // Rename these sub-categories
+                category_ = "Skill";
+                if(icon_.find("/Art/2DItems/Gems/VaalGems/") != std::string::npos) {
+                    category_vector_.push_back(category_);
+                    category_ = "Vaal";
+                }
+            } else if(category_ == "Supportgem") {
+                category_ = "Support";
+            } else if(category_ == "Bow" || category_ == "Staff") {
+                // Sub-categories these categories under handedness
+                category_vector_.push_back("TwoHand");
+            } else if(category_ == "Claw" || category_ == "Dagger" || category_ == "Sceptre" || category_ == "Wand") {
+                category_vector_.push_back("OneHand");
+            } else if(category_ == "Oneaxe") {
+                // Sub-categories these categories under handedness and rename them
+                category_vector_.push_back("OneHand");
+                category_ = "Axe";
+            } else if(category_ == "Onemace") {
+                category_vector_.push_back("OneHand");
+                category_ = "Mace";
+            } else if(category_ == "Onesword") {
+                category_vector_.push_back("OneHand");
+                category_ = "Sword";
+            } else if(category_ == "Twoaxe") {
+                category_vector_.push_back("TwoHand");
+                category_ = "Axe";
+            } else if(category_ == "Twomace") {
+                category_vector_.push_back("TwoHand");
+                category_ = "Mace";
+            } else if(category_ == "Twosword") {
+                category_vector_.push_back("TwoHand");
+                category_ = "Sword";
+            }
+
+            category_vector_.push_back(category_);
+        } else if(category_ == "Maps") {
+            // Use icon path to determine possible expansion sub-category
+            std::smatch sm;
+            if(std::regex_search(icon_, sm, std::regex("/Art/2DItems/Maps/(.*)/"))) {
+                std::string match = sm.str(1);
+                std::vector<std::string> iconsubs;
+                boost::split(iconsubs, match, boost::is_any_of("/"));
+                std::string sub = iconsubs[0];
+                if(sub == "Atlas2Maps") {
+                    category_vector_.push_back("3.1");
+                    if(iconsubs.size() > 1) {
+                        sub = iconsubs[1];  // Typically "New"
+                        Util::Capitalise(sub);
+                        category_vector_.push_back(sub);
+                    }
+                } else if(sub == "AtlasMaps") {
+                    category_vector_.push_back("2.4");
+                } else if(sub == "act4maps") {
+                    category_vector_.push_back("2.0");
+                } else {
+                    Util::Capitalise(sub);
+                    category_vector_.push_back(sub);
+                }
+            } else {
+                if(icon_.find("/Art/2DItems/Maps/Map") != std::string::npos) {
+                    // Doesn't find all because of some maps like FairgravesMap01.png, olmec.png, etc. They'll end up in Maps.Misc, then moved to Maps.Older Uniques
+                    category_vector_.push_back("Original");
+                } else if(icon_.find("/Art/2DItems/Currency/Breach/") != std::string::npos) {
+                    // Isn't really a map, has no property named Map Tier
+                    category_vector_.pop_back();
+                    category_vector_.push_back("Currency");
+                    category_vector_.push_back("Breach");
+                } else {
+                    category_vector_.push_back("Misc");
+
+                    if(json.HasMember("properties") && json["properties"].IsArray()) {
+                        for(auto prop_it = json["properties"].Begin(); prop_it != json["properties"].End(); ++prop_it) {
+                            auto &prop = *prop_it;
+                            if(!prop.HasMember("name") || !prop["name"].IsString() || !prop.HasMember("values") || !prop["values"].IsArray())
+                                continue;
+                            std::string name = prop["name"].GetString();
+                            if(name == "Map Tier") {
+                                category_vector_.pop_back();
+                                category_vector_.push_back("Older Uniques");    // Future ones might fall under a new /Maps/ icon path
+                            }
+                            // Else determine if Sacrifice/Mortal/Offering/etc fragment?
+                        }
+                    }
+                }
+            }
+        } else if(category_ == "Currency") {
+            if(icon_.find("/Art/2DItems/Currency/Breach/") != std::string::npos) {
+                category_vector_.push_back("Breach");
+            } else if(icon_.find("/Art/2DItems/Currency/Essence/") != std::string::npos) {
+                category_vector_.push_back("Essence");
+            }
+        }
+    }
+    category_ = boost::join(category_vector_, ".");
+    boost::to_lower(category_);
+
+}
+
 double Item::DPS() const {
     return pDPS() + eDPS() + cDPS();
 }
@@ -374,4 +467,13 @@ bool Item::operator<(const Item &rhs) const {
     std::string name = PrettyName();
     std::string rhs_name = rhs.PrettyName();
     return std::tie(name,uid_,hash_) < std::tie(rhs_name, rhs.uid_, hash_);
+}
+
+bool Item::Wearable() {
+    return (category_ == "flasks"
+            || category_ == "amulet" || category_ == "ring" || category_ == "belt"
+            || category_.find("armour") != std::string::npos
+            || category_.find("weapons") != std::string::npos
+            || category_.find("jewels") != std::string::npos
+    );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -97,7 +97,7 @@ Item::Item(const rapidjson::Value &json) :
     if (json.HasMember("shaper") && json["shaper"].IsBool() && json["shaper"].GetBool())
         baseType_ = BASE_SHAPER;
     if (json.HasMember("elder") && json["elder"].IsBool() && json["elder"].GetBool()) {
-        if(baseType_ != BASE_NORMAL) {
+        if (baseType_ != BASE_NORMAL) {
             QLOG_WARN() << PrettyName().c_str() << " has multiple conflicting base type attributes.";
         }
         baseType_ = BASE_ELDER;
@@ -271,15 +271,15 @@ void Item::CalculateCategories(const rapidjson::Value &json) {
         category_ = itr->name.GetString();
         category_ = Util::Capitalise(category_);
 
-        if(category_ == "Cards") {
+        if (category_ == "Cards") {
             category_ = "Divination cards";
         }
 
         category_vector_.push_back(category_);
-        if( itr->value.IsArray() && !itr->value.Empty() ) {
+        if (itr->value.IsArray() && !itr->value.Empty()) {
             // Handle sub-categories
 
-            if(category_ == "Accessories") {    // Elevate accessories sub-categories to their own top level categories
+            if (category_ == "Accessories") {    // Elevate accessories sub-categories to their own top level categories
                 category_vector_.pop_back();
                 // If amulet and .HasMember("talismanTier") (which is also checked after CalculateCategories()), add Talisman sub-category?
             }
@@ -292,70 +292,70 @@ void Item::CalculateCategories(const rapidjson::Value &json) {
             category_ = itr->value[0].GetString();
             category_ = Util::Capitalise(category_);
 
-            if(category_ == "Activegem") {
+            if (category_ == "Activegem") {
                 // Rename these sub-categories
                 category_ = "Skill";
-                if(icon_.find("/Art/2DItems/Gems/VaalGems/") != std::string::npos) {
+                if (icon_.find("/Art/2DItems/Gems/VaalGems/") != std::string::npos) {
                     category_vector_.push_back(category_);
                     category_ = "Vaal";
                 }
-            } else if(category_ == "Supportgem") {
+            } else if (category_ == "Supportgem") {
                 category_ = "Support";
-            } else if(category_ == "Bow" || category_ == "Staff") {
+            } else if (category_ == "Bow" || category_ == "Staff") {
                 // Sub-categories these categories under handedness
                 category_vector_.push_back("TwoHand");
-            } else if(category_ == "Claw" || category_ == "Dagger" || category_ == "Sceptre" || category_ == "Wand") {
+            } else if (category_ == "Claw" || category_ == "Dagger" || category_ == "Sceptre" || category_ == "Wand") {
                 category_vector_.push_back("OneHand");
-            } else if(category_ == "Oneaxe") {
+            } else if (category_ == "Oneaxe") {
                 // Sub-categories these categories under handedness and rename them
                 category_vector_.push_back("OneHand");
                 category_ = "Axe";
-            } else if(category_ == "Onemace") {
+            } else if (category_ == "Onemace") {
                 category_vector_.push_back("OneHand");
                 category_ = "Mace";
-            } else if(category_ == "Onesword") {
+            } else if (category_ == "Onesword") {
                 category_vector_.push_back("OneHand");
                 category_ = "Sword";
-            } else if(category_ == "Twoaxe") {
+            } else if (category_ == "Twoaxe") {
                 category_vector_.push_back("TwoHand");
                 category_ = "Axe";
-            } else if(category_ == "Twomace") {
+            } else if (category_ == "Twomace") {
                 category_vector_.push_back("TwoHand");
                 category_ = "Mace";
-            } else if(category_ == "Twosword") {
+            } else if (category_ == "Twosword") {
                 category_vector_.push_back("TwoHand");
                 category_ = "Sword";
             }
 
             category_vector_.push_back(category_);
-        } else if(category_ == "Maps") {
+        } else if (category_ == "Maps") {
             // Use icon path to determine possible expansion sub-category
             std::smatch sm;
-            if(std::regex_search(icon_, sm, std::regex("/Art/2DItems/Maps/(.*)/"))) {
+            if (std::regex_search(icon_, sm, std::regex("/Art/2DItems/Maps/(.*)/"))) {
                 std::string match = sm.str(1);
                 std::vector<std::string> iconsubs;
                 boost::split(iconsubs, match, boost::is_any_of("/"));
                 std::string sub = iconsubs[0];
-                if(sub == "Atlas2Maps") {
+                if (sub == "Atlas2Maps") {
                     category_vector_.push_back("3.1");
-                    if(iconsubs.size() > 1) {
+                    if (iconsubs.size() > 1) {
                         sub = iconsubs[1];  // Typically "New"
                         sub = Util::Capitalise(sub);
                         category_vector_.push_back(sub);
                     }
-                } else if(sub == "AtlasMaps") {
+                } else if (sub == "AtlasMaps") {
                     category_vector_.push_back("2.4");
-                } else if(sub == "act4maps") {
+                } else if (sub == "act4maps") {
                     category_vector_.push_back("2.0");
                 } else {
                     Util::Capitalise(sub);
                     category_vector_.push_back(sub);
                 }
             } else {
-                if(icon_.find("/Art/2DItems/Maps/Map") != std::string::npos) {
+                if (icon_.find("/Art/2DItems/Maps/Map") != std::string::npos) {
                     // Doesn't find all because of some maps like FairgravesMap01.png, olmec.png, etc. They'll end up in Maps.Misc, then moved to Maps.Older Uniques
                     category_vector_.push_back("Original");
-                } else if(icon_.find("/Art/2DItems/Currency/Breach/") != std::string::npos) {
+                } else if (icon_.find("/Art/2DItems/Currency/Breach/") != std::string::npos) {
                     // Isn't really a map, has no property named Map Tier
                     category_vector_.pop_back();
                     category_vector_.push_back("Currency");
@@ -363,12 +363,12 @@ void Item::CalculateCategories(const rapidjson::Value &json) {
                 } else {
                     category_vector_.push_back("Misc");
 
-                    if(json.HasMember("properties") && json["properties"].IsArray()) {
-                        for(auto &prop : json["properties"]) {
-                            if(!prop.HasMember("name") || !prop["name"].IsString() || !prop.HasMember("values") || !prop["values"].IsArray())
+                    if (json.HasMember("properties") && json["properties"].IsArray()) {
+                        for (auto &prop : json["properties"]) {
+                            if (!prop.HasMember("name") || !prop["name"].IsString() || !prop.HasMember("values") || !prop["values"].IsArray())
                                 continue;
                             std::string name = prop["name"].GetString();
-                            if(name == "Map Tier") {
+                            if (name == "Map Tier") {
                                 category_vector_.pop_back();
                                 category_vector_.push_back("Older Uniques");    // Future ones might fall under a new /Maps/ icon path
                                 break;
@@ -378,10 +378,10 @@ void Item::CalculateCategories(const rapidjson::Value &json) {
                     }
                 }
             }
-        } else if(category_ == "Currency") {
-            if(icon_.find("/Art/2DItems/Currency/Breach/") != std::string::npos) {
+        } else if (category_ == "Currency") {
+            if (icon_.find("/Art/2DItems/Currency/Breach/") != std::string::npos) {
                 category_vector_.push_back("Breach");
-            } else if(icon_.find("/Art/2DItems/Currency/Essence/") != std::string::npos) {
+            } else if (icon_.find("/Art/2DItems/Currency/Essence/") != std::string::npos) {
                 category_vector_.push_back("Essence");
             }
         }

--- a/src/item.h
+++ b/src/item.h
@@ -113,7 +113,7 @@ public:
     const ModTable &mod_table() const { return mod_table_; }
     int ilvl() const { return ilvl_; }
     bool operator<(const Item &other) const;
-    bool Wearable();
+    bool Wearable() const;
 
 private:
     void CalculateCategories(const rapidjson::Value &json);

--- a/src/item.h
+++ b/src/item.h
@@ -64,6 +64,12 @@ class Item {
 public:
     typedef const std::unordered_map<std::string, std::string> CategoryReplaceMap;
 
+    enum BASE_TYPES {
+        BASE_NORMAL,
+        BASE_SHAPER,
+        BASE_ELDER
+    };
+
     explicit Item(const rapidjson::Value &json);
     Item(const std::string &name, const ItemLocation &location); // used by tests
     std::string name() const { return name_; }
@@ -73,8 +79,9 @@ public:
     bool corrupted() const { return corrupted_; }
     bool crafted() const { return crafted_; }
     bool enchanted() const { return enchanted_; }
-    bool shaper() const { return shaper_; }
-    bool elder() const { return elder_; }
+    BASE_TYPES baseType() const { return baseType_; }
+    bool shaper() const { return baseType_ == BASE_SHAPER; }
+    bool elder() const { return baseType_ == BASE_ELDER; }
     int w() const { return w_; }
     int h() const { return h_; }
     int frameType() const { return frameType_; }
@@ -106,10 +113,10 @@ public:
     const ModTable &mod_table() const { return mod_table_; }
     int ilvl() const { return ilvl_; }
     bool operator<(const Item &other) const;
-    static const size_t k_CategoryLevels = 3;
-    static const std::array<CategoryReplaceMap, k_CategoryLevels> replace_map_;
+    bool Wearable();
 
 private:
+    void CalculateCategories(const rapidjson::Value &json);
     // The point of GenerateMods is to create combined (e.g. implicit+explicit) poe.trade-like mod map to be searched by mod filter.
     // For now it only does that for a small chosen subset of mods (think "popular" + "pseudo" sections at poe.trade)
     void GenerateMods(const rapidjson::Value &json);
@@ -124,8 +131,7 @@ private:
     bool corrupted_;
     bool crafted_;
     bool enchanted_;
-    bool shaper_;
-    bool elder_;
+    BASE_TYPES baseType_;
     int w_, h_;
     int frameType_;
     std::string icon_;

--- a/src/itemconstants.h
+++ b/src/itemconstants.h
@@ -2,9 +2,6 @@
 
 #include <map>
 
-const int PIXELS_PER_SLOT = 47;
-const int INVENTORY_SLOTS = 12;
-
 enum FRAME_TYPES {
     FRAME_TYPE_NORMAL = 0,
     FRAME_TYPE_MAGIC = 1,
@@ -24,11 +21,8 @@ enum ELEMENTAL_DAMAGE_TYPES {
     ED_LIGHTNING = 6,
 };
 
-const int LINKH_HEIGHT = 16;
-const int LINKH_WIDTH = 38;
-const int LINKV_HEIGHT = LINKH_WIDTH;
-const int LINKV_WIDTH = LINKH_HEIGHT;
-
+const int PIXELS_PER_SLOT = 47;
+const int INVENTORY_SLOTS = 12;
 const int PIXELS_PER_MINIMAP_SLOT = 10;
 const int MINIMAP_SIZE = INVENTORY_SLOTS * PIXELS_PER_MINIMAP_SLOT;
 

--- a/src/itemtooltip.cpp
+++ b/src/itemtooltip.cpp
@@ -28,6 +28,11 @@
 #include "item.h"
 #include "util.h"
 
+
+static const int LINKH_HEIGHT = 16;
+static const int LINKH_WIDTH = 38;
+static const int LINKV_HEIGHT = LINKH_WIDTH;
+static const int LINKV_WIDTH = LINKH_HEIGHT;
 static const QImage link_h(":/sockets/linkH.png");
 static const QImage link_v(":/sockets/linkV.png");
 static const QImage elder_1x1(":/backgrounds/ElderBackground_1x1.png");
@@ -44,6 +49,15 @@ static const QImage shaper_2x1(":/backgrounds/ShaperBackground_2x1.png");
 static const QImage shaper_2x2(":/backgrounds/ShaperBackground_2x2.png");
 static const QImage shaper_2x3(":/backgrounds/ShaperBackground_2x3.png");
 static const QImage shaper_2x4(":/backgrounds/ShaperBackground_2x4.png");
+static const QImage shaper_icon(":/tooltip/ShaperItemSymbol.png");
+static const QImage elder_icon(":/tooltip/ElderItemSymbol.png");
+static const int HEADER_SINGLELINE_WIDTH = 29;
+static const int HEADER_SINGLELINE_HEIGHT = 34;
+static const int HEADER_DOUBLELINE_WIDTH = 44;
+static const int HEADER_DOUBLELINE_HEIGHT = 54;
+static const QSize HEADER_SINGLELINE_SIZE(HEADER_SINGLELINE_WIDTH, HEADER_SINGLELINE_HEIGHT);
+static const QSize HEADER_DOUBLELINE_SIZE(HEADER_DOUBLELINE_WIDTH, HEADER_DOUBLELINE_HEIGHT);
+static const QSize HEADER_OVERLAY_SIZE(27, 27);
 
 /*
     PoE colors:
@@ -223,9 +237,9 @@ static void UpdateMinimap(const Item &item, Ui::MainWindow *ui) {
     ui->minimapLabel->setPixmap(pixmap);
 }
 
-void GenerateItemHeaderSide(const Item &item, Ui::MainWindow *ui, std::string header_path_prefix, bool singleline, bool leftNotRight) {
+void GenerateItemHeaderSide(QLabel *itemHeader, bool leftNotRight, std::string header_path_prefix, bool singleline, Item::BASE_TYPES base) {
     QImage header(QString::fromStdString(header_path_prefix + (leftNotRight ? "Left.png" : "Right.png")));
-    QSize header_size = singleline ? QSize(29, 34) : QSize(44, 54);
+    QSize header_size = singleline ? HEADER_SINGLELINE_SIZE : HEADER_DOUBLELINE_SIZE;
     header = header.scaled(header_size);
 
     QPixmap header_pixmap(header_size);
@@ -233,33 +247,19 @@ void GenerateItemHeaderSide(const Item &item, Ui::MainWindow *ui, std::string he
     QPainter header_painter(&header_pixmap);
     header_painter.drawImage(0, 0, header);
 
-    if(item.shaper() || item.elder()){
-        std::string overlay = ":/tooltip/";
-        if(item.shaper()) {
-            overlay += "Shaper";
-        }
-        if(item.elder()) {
-            overlay += "Elder";
-        }
-        overlay += "ItemSymbol.png";
-
-        QImage overlay_image(QString::fromStdString(overlay));
-        overlay_image = overlay_image.scaled(27, 27);
+    if(base == Item::BASE_SHAPER || base == Item::BASE_ELDER) {
+        QImage overlay_image = base == Item::BASE_SHAPER ? shaper_icon : elder_icon;
+        overlay_image = overlay_image.scaled(HEADER_OVERLAY_SIZE);
         int overlay_x = singleline ? (leftNotRight ? 2: 1) : (leftNotRight ? 2: 15);
         int overlay_y = (int) ( 0.5 * (header.height() - overlay_image.height()) );
         header_painter.drawImage(overlay_x, overlay_y, overlay_image);
     }
 
-    if(leftNotRight) {
-        ui->itemHeaderLeft->setFixedSize(header_size);
-        ui->itemHeaderLeft->setPixmap(header_pixmap);
-    } else {
-        ui->itemHeaderRight->setFixedSize(header_size);
-        ui->itemHeaderRight->setPixmap(header_pixmap);
-    }
+    itemHeader->setFixedSize(header_size);
+    itemHeader->setPixmap(header_pixmap);
 }
 
-void GenerateItemTooltip(const Item &item, Ui::MainWindow *ui) {
+void UpdateItemTooltip(const Item &item, Ui::MainWindow *ui) {
     size_t frame = item.frameType();
     if (frame >= FrameToKey.size())
         frame = 0;
@@ -273,18 +273,18 @@ void GenerateItemTooltip(const Item &item, Ui::MainWindow *ui) {
     if (singleline) {
         ui->itemNameFirstLine->hide();
         ui->itemNameSecondLine->setAlignment(Qt::AlignCenter);
-        ui->itemNameContainerWidget->setFixedSize(16777215, 34);
+        ui->itemNameContainerWidget->setFixedSize(16777215, HEADER_SINGLELINE_HEIGHT);
     } else {
         ui->itemNameFirstLine->show();
         ui->itemNameFirstLine->setAlignment(Qt::AlignBottom | Qt::AlignHCenter);
         ui->itemNameSecondLine->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
-        ui->itemNameContainerWidget->setFixedSize(16777215, 54);
+        ui->itemNameContainerWidget->setFixedSize(16777215, HEADER_DOUBLELINE_HEIGHT);
     }
     std::string suffix = (singleline && (frame == FRAME_TYPE_RARE || frame == FRAME_TYPE_UNIQUE)) ? "SingleLine" : "";
     std::string header_path_prefix = ":/tooltip/ItemsHeader" + key + suffix;
 
-    GenerateItemHeaderSide(item, ui, header_path_prefix, singleline, true);
-    GenerateItemHeaderSide(item, ui, header_path_prefix, singleline, false);
+    GenerateItemHeaderSide(ui->itemHeaderLeft, true, header_path_prefix, singleline, item.baseType());
+    GenerateItemHeaderSide(ui->itemHeaderRight, false, header_path_prefix, singleline, item.baseType());
 
     ui->itemNameContainerWidget->setStyleSheet(("border-radius: 0px; border: 0px; border-image: url(" + header_path_prefix + "Middle.png);").c_str());
 
@@ -296,20 +296,16 @@ void GenerateItemTooltip(const Item &item, Ui::MainWindow *ui) {
     ui->itemNameSecondLine->setStyleSheet(css.c_str());
 }
 
-void GenerateItemIcon(const Item &item, const QImage &image, Ui::MainWindow *ui) {
-    int height = item.h();
-    int width = item.w();
-    int socket_rows = 0;
-    int socket_columns = 0;
-    // this will ensure we have enough room to draw the slots
-    QPixmap pixmap(width * PIXELS_PER_SLOT, height * PIXELS_PER_SLOT);
+QPixmap GenerateItemSockets(const int width, const int height, const std::vector<ItemSocket> &sockets) {
+    QPixmap pixmap(width * PIXELS_PER_SLOT, height * PIXELS_PER_SLOT);  // This will ensure we have enough room to draw the slots
     pixmap.fill(Qt::transparent);
     QPainter painter(&pixmap);
 
+    int socket_rows = 0;
+    int socket_columns = 0;
     ItemSocket prev = { 255, '-' };
     size_t i = 0;
 
-    auto &sockets = item.text_sockets();
     if (sockets.size() == 0) {
         // Do nothing
     } else if (sockets.size() == 1) {
@@ -337,27 +333,34 @@ void GenerateItemIcon(const Item &item, const QImage &image, Ui::MainWindow *ui)
                 socket_rows = qMax(row + 1, socket_rows);
                 painter.drawImage(PIXELS_PER_SLOT * column, PIXELS_PER_SLOT * row, socket_image);
                 if (link) {
-                    if (i == 1 || i == 3 || i == 5) {
-                        // horizontal link
-                        painter.drawImage(
-                            PIXELS_PER_SLOT - LINKH_WIDTH / 2,
-                            row * PIXELS_PER_SLOT + PIXELS_PER_SLOT / 2 - LINKH_HEIGHT / 2,
-                            link_h
-                        );
-                    } else if (i == 2) {
-                        painter.drawImage(
-                            PIXELS_PER_SLOT * 1.5 - LINKV_WIDTH / 2,
-                            row * PIXELS_PER_SLOT - LINKV_HEIGHT / 2,
-                            link_v
-                        );
-                    } else if (i == 4) {
-                        painter.drawImage(
-                            PIXELS_PER_SLOT / 2 - LINKV_WIDTH / 2,
-                            row * PIXELS_PER_SLOT - LINKV_HEIGHT / 2,
-                            link_v
-                        );
-                    } else {
-                        QLOG_ERROR() << "No idea how to draw link for" << item.PrettyName().c_str();
+                    switch(i){
+                        case 1:
+                        case 3:
+                        case 5:
+                            // horizontal link
+                            painter.drawImage(
+                                PIXELS_PER_SLOT - LINKH_WIDTH / 2,
+                                row * PIXELS_PER_SLOT + PIXELS_PER_SLOT / 2 - LINKH_HEIGHT / 2,
+                                link_h
+                            );
+                            break;
+                        case 2:
+                            painter.drawImage(
+                                PIXELS_PER_SLOT * 1.5 - LINKV_WIDTH / 2,
+                                row * PIXELS_PER_SLOT - LINKV_HEIGHT / 2,
+                                link_v
+                            );
+                            break;
+                        case 4:
+                            painter.drawImage(
+                                PIXELS_PER_SLOT / 2 - LINKV_WIDTH / 2,
+                                row * PIXELS_PER_SLOT - LINKV_HEIGHT / 2,
+                                link_v
+                            );
+                            break;
+                        default:
+                            QLOG_ERROR() << "No idea how to draw link for socket " << i;
+                            break;
                     }
                 }
             }
@@ -367,31 +370,75 @@ void GenerateItemIcon(const Item &item, const QImage &image, Ui::MainWindow *ui)
         }
     }
 
-    QPixmap cropped = pixmap.copy(0, 0, PIXELS_PER_SLOT * socket_columns,
-                                        PIXELS_PER_SLOT * socket_rows);
+    return pixmap.copy(0, 0, PIXELS_PER_SLOT * socket_columns,
+                                            PIXELS_PER_SLOT * socket_rows);
+}
 
-    QPixmap base(image.width(), image.height());
-    base.fill(Qt::transparent);
-    QPainter overlay(&base);
+QPixmap GenerateItemIcon(const Item &item, const QImage &image) {
+    const int height = item.h();
+    const int width = item.w();
+
+    QPixmap layered(image.width(), image.height());
+    layered.fill(Qt::transparent);
+    QPainter layered_painter(&layered);
 
     if(item.shaper() || item.elder()){
-        std::string background = ":/backgrounds/";
+        // Assumes width <= 2
+        const QImage *background_image = nullptr;
         if(item.shaper()) {
-            background += "Shaper";
+            switch(height) {
+                case 1:
+                    background_image = width == 1 ? &shaper_1x1 : &shaper_2x1;
+                    break;
+                case 2:
+                    background_image = width == 1 ? nullptr : &shaper_2x2;
+                    break;
+                case 3:
+                    background_image = width == 1 ? &shaper_1x3 : &shaper_2x3;
+                    break;
+                case 4:
+                    background_image = width == 1 ? &shaper_1x4 : &shaper_2x4;
+                    break;
+                default:
+                    break;
+            }
+        } else {    // Elder
+            switch(height) {
+                case 1:
+                    background_image = width == 1 ? &elder_1x1 : &elder_2x1;
+                    break;
+                case 2:
+                    background_image = width == 1 ? nullptr : &elder_2x2;
+                    break;
+                case 3:
+                    background_image = width == 1 ? &elder_1x3 : &elder_2x3;
+                    break;
+                case 4:
+                    background_image = width == 1 ? &elder_1x4 : &elder_2x4;
+                    break;
+                default:
+                    break;
+            }
         }
-        if(item.elder()) {
-            background += "Elder";
+        if(background_image) {
+            layered_painter.drawImage(0, 0, *background_image);
+        } else {
+            QLOG_ERROR() << "Problem drawing background for " << item.PrettyName().c_str();
         }
-        background += "Background_" + std::to_string(width) + "x" + std::to_string(height) + ".png";
-
-        QImage background_image(QString::fromStdString(background));
-        overlay.drawImage(0, 0, background_image);
     }
 
-    overlay.drawImage(0, 0, image);
+    layered_painter.drawImage(0, 0, image);
 
-    overlay.drawPixmap((int)(0.5*(image.width() - cropped.width())),
-                       (int)(0.5*(image.height() - cropped.height())), cropped);
+    if(item.text_sockets().size() > 0) {
+        QPixmap sockets = GenerateItemSockets(width, height, item.text_sockets());
 
-    ui->imageLabel->setPixmap(base);
+        layered_painter.drawPixmap((int)(0.5*(image.width() - sockets.width())),
+                       (int)(0.5*(image.height() - sockets.height())), sockets);    // Center sockets on overall image
+    }
+
+    return layered;
+}
+
+QString GenerateItemPOBText(const Item &item) {
+    return QString::fromStdString(item.PrettyName());
 }

--- a/src/itemtooltip.cpp
+++ b/src/itemtooltip.cpp
@@ -247,7 +247,7 @@ void GenerateItemHeaderSide(QLabel *itemHeader, bool leftNotRight, std::string h
     QPainter header_painter(&header_pixmap);
     header_painter.drawImage(0, 0, header);
 
-    if(base == Item::BASE_SHAPER || base == Item::BASE_ELDER) {
+    if (base == Item::BASE_SHAPER || base == Item::BASE_ELDER) {
         QImage overlay_image = base == Item::BASE_SHAPER ? shaper_icon : elder_icon;
         overlay_image = overlay_image.scaled(HEADER_OVERLAY_SIZE);
         int overlay_x = singleline ? (leftNotRight ? 2: 1) : (leftNotRight ? 2: 15);
@@ -382,10 +382,10 @@ QPixmap GenerateItemIcon(const Item &item, const QImage &image) {
     layered.fill(Qt::transparent);
     QPainter layered_painter(&layered);
 
-    if(item.shaper() || item.elder()){
+    if (item.shaper() || item.elder()){
         // Assumes width <= 2
         const QImage *background_image = nullptr;
-        if(item.shaper()) {
+        if (item.shaper()) {
             switch(height) {
                 case 1:
                     background_image = width == 1 ? &shaper_1x1 : &shaper_2x1;
@@ -420,7 +420,7 @@ QPixmap GenerateItemIcon(const Item &item, const QImage &image) {
                     break;
             }
         }
-        if(background_image) {
+        if (background_image) {
             layered_painter.drawImage(0, 0, *background_image);
         } else {
             QLOG_ERROR() << "Problem drawing background for " << item.PrettyName().c_str();
@@ -429,7 +429,7 @@ QPixmap GenerateItemIcon(const Item &item, const QImage &image) {
 
     layered_painter.drawImage(0, 0, image);
 
-    if(item.text_sockets().size() > 0) {
+    if (item.text_sockets().size() > 0) {
         QPixmap sockets = GenerateItemSockets(width, height, item.text_sockets());
 
         layered_painter.drawPixmap((int)(0.5*(image.width() - sockets.width())),

--- a/src/itemtooltip.h
+++ b/src/itemtooltip.h
@@ -24,5 +24,6 @@
 #include "item.h"
 #include "ui_mainwindow.h"
 
-void GenerateItemTooltip(const Item &item, Ui::MainWindow *ui);
-void GenerateItemIcon(const Item &item, const QImage &image, Ui::MainWindow *ui);
+void UpdateItemTooltip(const Item &item, Ui::MainWindow *ui);
+QPixmap GenerateItemIcon(const Item &item, const QImage &image);
+QString GenerateItemPOBText(const Item &item);

--- a/src/logindialog.cpp
+++ b/src/logindialog.cpp
@@ -278,7 +278,7 @@ void LoginDialog::LoadSettings() {
 
 void LoginDialog::SaveSettings() {
     QSettings settings(settings_path_.c_str(), QSettings::IniFormat);
-    if(ui->rembmeCheckBox->isChecked()) {
+    if (ui->rembmeCheckBox->isChecked()) {
         settings.setValue("session_id", session_id_);
         settings.setValue("league", ui->leagueComboBox->currentText());
     } else {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -898,7 +898,7 @@ void MainWindow::on_pobTooltipButton_clicked() {
         return;
     }
     // if category isn't wearable, including flasks, don't do anything
-    if(!current_item_->Wearable()) {
+    if (!current_item_->Wearable()) {
         QLOG_WARN() << current_item_->PrettyName().c_str() << ", category:" << current_item_->category().c_str() << ", should not have been exportable.";
         return;
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -458,7 +458,7 @@ void MainWindow::OnImageFetched(QNetworkReply *reply) {
     image_cache_->Set(url, image);
 
     if (current_item_ && (url == current_item_->icon() || url == POE_WEBCDN + current_item_->icon()))
-        ui->imageLabel->setPixmap( GenerateItemIcon(*current_item_, image) );
+        ui->imageLabel->setPixmap(GenerateItemIcon(*current_item_, image));
 }
 
 void MainWindow::SetCurrentSearch(Search *search) {
@@ -661,7 +661,7 @@ void MainWindow::UpdateCurrentItem() {
     if (!image_cache_->Exists(icon))
         image_network_manager_->get(QNetworkRequest(QUrl(icon.c_str())));
     else
-        ui->imageLabel->setPixmap( GenerateItemIcon(*current_item_, image_cache_->Get(icon)) );
+        ui->imageLabel->setPixmap(GenerateItemIcon(*current_item_, image_cache_->Get(icon)));
 
     ui->locationLabel->setText(current_item_->location().GetHeader().c_str());
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -122,6 +122,7 @@ private slots:
     void on_actionLight_triggered(bool toggle);
     void on_actionExport_currency_triggered();
     void on_uploadTooltipButton_clicked();
+    void on_pobTooltipButton_clicked();
 
 private:
     void ModelViewRefresh();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -217,7 +217,7 @@ void Search::Activate(const Items &items) {
 void Search::SaveViewProperties() {
     expanded_property_.clear();
     auto rowCount = model_->rowCount();
-    for( int row = 0; row < rowCount; ++row ) {
+    for (int row = 0; row < rowCount; ++row) {
         QModelIndex index = model_->index( row, 0, QModelIndex());
         if (index.isValid() && view_->isExpanded(index)) {
             expanded_property_.insert(bucket(row)->location().GetHeader());
@@ -228,7 +228,7 @@ void Search::SaveViewProperties() {
 void Search::RestoreViewProperties() {
     if (!expanded_property_.empty()) {
         auto rowCount = model_->rowCount();
-        for( int row = 0; row < rowCount; ++row ) {
+        for (int row = 0; row < rowCount; ++row) {
             QModelIndex index = model_->index( row, 0, QModelIndex());
             // Block signals else columns will be resized on every expand which can be super slow.
             view_->blockSignals(true);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -173,6 +173,10 @@ bool Util::MatchMod(const char *match, const char *mod, double *output) {
     return !*pmatch && !*pmod;
 }
 
+void Util::Capitalise(std::string &str) {
+    str[0] = static_cast<std::string::value_type>(toupper(str[0]));   //  Set the first character to upper case
+}
+
 std::string Util::TimeAgoInWords(const QDateTime buyout_time){
     QDateTime current_date = QDateTime::currentDateTime();
     qint64 secs = buyout_time.secsTo(current_date);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -173,8 +173,10 @@ bool Util::MatchMod(const char *match, const char *mod, double *output) {
     return !*pmatch && !*pmod;
 }
 
-void Util::Capitalise(std::string &str) {
-    str[0] = static_cast<std::string::value_type>(toupper(str[0]));   //  Set the first character to upper case
+std::string Util::Capitalise(const std::string &str) {
+    std::string capitalised = str;
+    capitalised[0] = static_cast<std::string::value_type>(toupper(capitalised[0]));   //  Set the first character to upper case
+    return capitalised;
 }
 
 std::string Util::TimeAgoInWords(const QDateTime buyout_time){

--- a/src/util.h
+++ b/src/util.h
@@ -99,6 +99,8 @@ std::vector<std::string> StringSplit(const std::string &str, char delim);
 */
 bool MatchMod(const char *match, const char *mod, double *output);
 
+void Capitalise(std::string &str);
+
 std::string TimeAgoInWords(const QDateTime buyout_time);
 
 std::string Decode(const std::string &entity);

--- a/src/util.h
+++ b/src/util.h
@@ -99,7 +99,7 @@ std::vector<std::string> StringSplit(const std::string &str, char delim);
 */
 bool MatchMod(const char *match, const char *mod, double *output);
 
-void Capitalise(std::string &str);
+std::string Capitalise(const std::string &str);
 
 std::string TimeAgoInWords(const QDateTime buyout_time);
 

--- a/test/testdata.cpp
+++ b/test/testdata.cpp
@@ -34,6 +34,152 @@ const std::string kItem1 =
    "ing Resistance\",\"15% increased Block and Stun Recovery\"],\"frameType\":2,\"x\":0,\"y\":0,\"inventoryId\": \"Helm"
    "\",\"socketedItems\":[], \"_type\": 0, \"_tab_label\": \"x\", \"_tab\": 0, \"_x\": 0, \"_y\": 0}";
 
+const std::string kCategoriesItemCard =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":0,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Divi"
+   "nation\\/InventoryIcon.png?scale=1&scaleIndex=0&stackSize=1&w=1&h=1&v=a8ae131b97fad3c64de0e6d9f250d743\",\"league\""
+   ":\"Standard\",\"id\":\"9aae0ab91a6fd7ceef94538b74a5b0cc770a966f3089295cf0a45bc0e48bad84\",\"name\":\"\",\"typeLine"
+   "\":\"The King\'s Heart\",\"identified\":true,\"properties\":[{\"name\":\"Stack Size\",\"values\":[[\"1\\/8\",0]],\""
+   "displayMode\":0}],\"explicitMods\":[\"<uniqueitem>{Kaom\'s Heart}\"],\"flavourText\":[\"<size:31>{500 times Kaom\'s"
+   " axe fell, 500 times Kaom\'s Heart splintered. Finally, all that remained was a terrible, heartless Fury.}\"],\"fra"
+   "meType\":6,\"stackSize\":1,\"maxStackSize\":8,\"artFilename\":\"TheKingsHeart\",\"category\":{\"cards\":[]},\"x\":8"
+   ",\"y\":11,\"inventoryId\":\"Stash3\"}";
+
+const std::string kCategoriesItemBelt =
+   "{\"verified\":false,\"w\":2,\"h\":1,\"ilvl\":80,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Bel"
+   "ts\\/AbyssBelt.png?scale=1&scaleIndex=0&w=2&h=1&v=cd7c25de181e6a77812020eb6e867971\",\"league\":\"Standard\",\"id\""
+   ":\"7aa1eaefc73c5fd0321c201675d17d3a1c9ef7ba2748b903cb8d4171a9a70637\",\"sockets\":[{\"group\":0,\"attr\":false,\"sC"
+   "olour\":\"A\"}],\"name\":\"Ambush Cord\",\"typeLine\":\"Stygian Vise\",\"identified\":true,\"requirements\":[{\"nam"
+   "e\":\"Level\",\"values\":[[\"64\",0]],\"displayMode\":0}],\"implicitMods\":[\"Has 1 Abyssal Socket\"],\"explicitMod"
+   "s\":[\"+49 to maximum Energy Shield\",\"18% reduced Flask Charges used\",\"18% increased Elemental Damage with Atta"
+   "ck Skills\"],\"frameType\":2,\"category\":{\"accessories\":[\"belt\"]},\"x\":0,\"y\":10,\"inventoryId\":\"Stash21\""
+   ",\"socketedItems\":[]}";
+
+const std::string kCategoriesItemEssence =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":0,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Curr"
+   "ency\\/Essence\\/Wrath5.png?scale=1&scaleIndex=3&stackSize=4&w=1&h=1&v=47288253244910c2da4f0bdda069b832\",\"league"
+   "\":\"Standard\",\"id\":\"ec18c882e5438ed72a71337f3dfb9a3acf0a3afccc068acbdcf18adf07784f02\",\"name\":\"\",\"typeLin"
+   "e\":\"Screaming Essence of Wrath\",\"identified\":true,\"properties\":[{\"name\":\"Stack Size\",\"values\":[[\"4\\/"
+   "9\",0]],\"displayMode\":0}],\"explicitMods\":[\"Upgrades a normal item to rare with one guaranteed property\",\"\","
+   "\"Two Handed Melee Weapon: Adds (5-16) to (200-211) Lightning Damage\",\"Other Weapon: Adds (4-11) to (133-140) Lig"
+   "htning Damage\",\"Armour: (36-41)% to Lightning Resistance\",\"Quiver: (36-41)% to Lightning Resistance\",\"Belt: ("
+   "36-41)% to Lightning Resistance\",\"Other Jewellery: (23-26)% increased Lightning Damage\"],\"descrText\":\"Right c"
+   "lick this item then left click a normal item to apply it.\",\"frameType\":5,\"stackSize\":4,\"maxStackSize\":5000,"
+   "\"category\":{\"currency\":[]},\"x\":44,\"y\":0,\"inventoryId\":\"Stash1\"}";
+
+const std::string kCategoriesItemVaalGem =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":0,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Gems"
+   "\\/VaalGems\\/VaalArc.png?scale=1&scaleIndex=3&w=1&h=1&v=b4f32328e279496ebb227521e8dce679\",\"support\":false,\"id"
+   "\":\"d1014d4e4e6ecaa53805cfa274069071d4b3d26aa0f8a9ac1680cb77f5ed0f47\",\"name\":\"\",\"typeLine\":\"Vaal Arc\",\"i"
+   "dentified\":true,\"corrupted\":true,\"properties\":[{\"name\":\"Vaal, Spell, Chaining, Lightning, Duration\",\"valu"
+   "es\":[],\"displayMode\":0},{\"name\":\"Level\",\"values\":[[\"14\",0]],\"displayMode\":0,\"type\":5},{\"name\":\"Ma"
+   "na Cost\",\"values\":[[\"22\",0]],\"displayMode\":0},{\"name\":\"Cast Time\",\"values\":[[\"0.80 sec\",0]],\"displa"
+   "yMode\":0},{\"name\":\"Critical Strike Chance\",\"values\":[[\"5.00%\",0]],\"displayMode\":0},{\"name\":\"Effective"
+   "ness of Added Damage\",\"values\":[[\"90%\",0]],\"displayMode\":0}],\"additionalProperties\":[{\"name\":\"Experienc"
+   "e\",\"values\":[[\"4312826\\/5099360\",0]],\"displayMode\":2,\"progress\":0.845758318901062,\"type\":20}],\"require"
+   "ments\":[{\"name\":\"Level\",\"values\":[[\"56\",0]],\"displayMode\":0},{\"name\":\"Int\",\"values\":[[\"125\",0]],"
+   "\"displayMode\":1}],\"secDescrText\":\"An arc of lightning stretches from the caster to a targeted enemy and chains"
+   " on to other nearby enemies. Each time the main beam chains it will also chain to a second enemy, but that secondar"
+   "y arc cannot chain further.\",\"explicitMods\":[\"Deals 80 to 456 Lightning Damage\",\"Chains +6 Times\",\"10% chan"
+   "ce to Shock enemies\",\"15% more Damage for each remaining Chain\",\"23% increased Effect of Shock\"],\"descrText\""
+   ":\"Place into an item socket of the right colour to gain this skill. Right click to remove from a socket.\",\"frame"
+   "Type\":4,\"category\":{\"gems\":[\"activegem\"]},\"socket\":1,\"colour\":\"I\",\"vaal\":{\"baseTypeName\":\"Arc\","
+   "\"properties\":[{\"name\":\"Souls Per Use\",\"values\":[[\"25\",0]],\"displayMode\":0},{\"name\":\"Can Store %0 Use"
+   "\",\"values\":[[\"1\",0]],\"displayMode\":3},{\"name\":\"Soul Gain Prevention\",\"values\":[[\"6 sec\",0]],\"displa"
+   "yMode\":0},{\"name\":\"Cast Time\",\"values\":[[\"0.80 sec\",0]],\"displayMode\":0},{\"name\":\"Critical Strike Cha"
+   "nce\",\"values\":[[\"5.00%\",0]],\"displayMode\":0},{\"name\":\"Effectiveness of Added Damage\",\"values\":[[\"180%"
+   "\",0]],\"displayMode\":0}],\"explicitMods\":[\"Deals 483 to 806 Lightning Damage\",\"Base duration is 4.00 seconds"
+   "\",\"Chains +8 Times\",\"Modifiers to Buff Duration also apply to this Skill\'s Soul Gain Prevention\",\"100% incre"
+   "ased Shock Duration on enemies\",\"100% chance to Shock enemies\",\"15% more Damage for each remaining Chain\",\"10"
+   "0% increased Effect of Shock\"],\"secDescrText\":\"A shocking arc of lightning stretches from the caster to a targe"
+   "ted enemy and chains to other nearby enemies. Each time the beam chains it will also chain simultaneously to a seco"
+   "nd enemy, but no enemy can be hit twice by the beams. Also grants a buff making you lucky when damaging enemies wit"
+   "h Arc for a short duration.\"}}";
+
+const std::string kCategoriesItemSupportGem =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":0,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Gems"
+   "\\/Support\\/IncreasedQuantity.png?scale=1&scaleIndex=0&w=1&h=1&v=b07c717ecf613d726e9edcbc0d66ff93\",\"support\":tr"
+   "ue,\"league\":\"Hardcore\",\"id\":\"01726cfdcd593fafa3137f11274505c8678fc982b93146363b424165d1de1fe8\",\"name\":\""
+   "\",\"typeLine\":\"Item Quantity Support\",\"identified\":true,\"properties\":[{\"name\":\"Support\",\"values\":[],"
+   "\"displayMode\":0},{\"name\":\"Level\",\"values\":[[\"3\",0]],\"displayMode\":0,\"type\":5}],\"additionalProperties"
+   "\":[{\"name\":\"Experience\",\"values\":[[\"210204\\/254061\",0]],\"displayMode\":2,\"progress\":0.827376127243042,"
+   "\"type\":20}],\"requirements\":[{\"name\":\"Level\",\"values\":[[\"30\",0]],\"displayMode\":0},{\"name\":\"Str\",\""
+   "values\":[[\"51\",0]],\"displayMode\":1}],\"secDescrText\":\"Supports any skill that can kill enemies.\",\"explicit"
+   "Mods\":[\"19% increased Quantity of Items Dropped by Enemies Slain from Supported Skills\"],\"descrText\":\"This is"
+   " a Support Gem. It does not grant a bonus to your character, but to skills in sockets connected to it. Place into a"
+   "n item socket connected to a socket containing the Active Skill Gem you wish to augment. Right click to remove from"
+   " a socket.\",\"frameType\":4,\"category\":{\"gems\":[\"supportgem\"]},\"x\":11,\"y\":4,\"inventoryId\":\"Stash5\"}";
+
+const std::string kCategoriesItemBow =
+   "{\"verified\":false,\"w\":2,\"h\":4,\"ilvl\":74,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Wea"
+   "pons\\/TwoHandWeapons\\/Bows\\/BowOfTheCouncil.png?scale=1&scaleIndex=0&w=2&h=4&v=ecb677fbcbc747a46df9fa5e1e919952"
+   "\",\"league\":\"Standard\",\"id\":\"b65efbb946441039d6a0bc0d224d01f732ec15828fcae511d6bde5a7d5a41622\",\"sockets\":"
+   "[{\"group\":0,\"attr\":\"D\",\"sColour\":\"G\"},{\"group\":1,\"attr\":\"D\",\"sColour\":\"G\"},{\"group\":1,\"attr"
+   "\":\"I\",\"sColour\":\"B\"},{\"group\":1,\"attr\":\"I\",\"sColour\":\"B\"},{\"group\":1,\"attr\":\"D\",\"sColour\":"
+   "\"G\"},{\"group\":1,\"attr\":\"D\",\"sColour\":\"G\"}],\"name\":\"Reach of the Council\",\"typeLine\":\"Spine Bow\""
+   ",\"identified\":true,\"properties\":[{\"name\":\"Bow\",\"values\":[],\"displayMode\":0},{\"name\":\"Quality\",\"val"
+   "ues\":[[\"+20%\",1]],\"displayMode\":0,\"type\":6},{\"name\":\"Physical Damage\",\"values\":[[\"84-249\",1]],\"disp"
+   "layMode\":0,\"type\":9},{\"name\":\"Critical Strike Chance\",\"values\":[[\"6.00%\",0]],\"displayMode\":0,\"type\":"
+   "12},{\"name\":\"Attacks per Second\",\"values\":[[\"1.49\",1]],\"displayMode\":0,\"type\":13}],\"requirements\":[{"
+   "\"name\":\"Level\",\"values\":[[\"68\",0]],\"displayMode\":0},{\"name\":\"Dex\",\"values\":[[\"212\",0]],\"displayM"
+   "ode\":1},{\"name\":\"Int\",\"values\":[[\"108\",0]],\"displayMode\":1}],\"explicitMods\":[\"44% increased Physical "
+   "Damage\",\"Adds 24 to 72 Physical Damage\",\"10% increased Attack Speed\",\"Bow Attacks fire 4 additional Arrows\","
+   "\"20% reduced Projectile Speed\"],\"flavourText\":[\"We stand together. We strike together.\"],\"frameType\":3,\"ca"
+   "tegory\":{\"weapons\":[\"bow\"]},\"x\":0,\"y\":0,\"inventoryId\":\"Weapon2\",\"socketedItems\":[]}";
+
+const std::string kCategoriesItemClaw =
+   "{\"verified\":false,\"w\":2,\"h\":2,\"ilvl\":70,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Wea"
+   "pons\\/OneHandWeapons\\/Claws\\/Claw5Unique2.png?scale=1&scaleIndex=0&w=2&h=2&v=1b50572643c65320c8726d57a01d5be4\","
+   "\"league\":\"Standard\",\"id\":\"f66fa2861857808c403ce958f1c38fcd7ed1bc8eda4ef5bf3f84f4f3edb99b09\",\"sockets\":[{"
+   "\"group\":0,\"attr\":\"D\",\"sColour\":\"G\"},{\"group\":0,\"attr\":\"D\",\"sColour\":\"G\"}],\"name\":\"Essentia S"
+   "anguis\",\"typeLine\":\"Eye Gouger\",\"identified\":true,\"properties\":[{\"name\":\"Claw\",\"values\":[],\"display"
+   "Mode\":0},{\"name\":\"Physical Damage\",\"values\":[[\"56-147\",1]],\"displayMode\":0,\"type\":9},{\"name\":\"Eleme"
+   "ntal Damage\",\"values\":[[\"1-50\",6]],\"displayMode\":0,\"type\":10},{\"name\":\"Critical Strike Chance\",\"value"
+   "s\":[[\"6.30%\",0]],\"displayMode\":0,\"type\":12},{\"name\":\"Attacks per Second\",\"values\":[[\"1.83\",1]],\"dis"
+   "playMode\":0,\"type\":13},{\"name\":\"Weapon Range\",\"values\":[[\"9\",0]],\"displayMode\":0,\"type\":14}],\"requi"
+   "rements\":[{\"name\":\"Level\",\"values\":[[\"64\",0]],\"displayMode\":0},{\"name\":\"Dex\",\"values\":[[\"113\",0]"
+   "],\"displayMode\":1},{\"name\":\"Int\",\"values\":[[\"113\",0]],\"displayMode\":1}],\"implicitMods\":[\"0.6% of Phy"
+   "sical Attack Damage Leeched as Life\"],\"explicitMods\":[\"+10% Chance to Block Attack Damage while Dual Wielding C"
+   "laws\",\"116% increased Physical Damage\",\"Adds 1 to 50 Lightning Damage\",\"22% increased Attack Speed\",\"+32 to"
+   " maximum Energy Shield\",\"Life Leech is applied to Energy Shield instead\"],\"flavourText\":[\"The darkest clouds "
+   "clashed and coupled,\\r\",\"giving birth to four lightning children of hate.\"],\"frameType\":3,\"category\":{\"wea"
+   "pons\":[\"claw\"]},\"x\":6,\"y\":6,\"inventoryId\":\"Stash4\",\"socketedItems\":[]}";
+
+const std::string kCategoriesItemFragment =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":0,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Maps"
+   "\\/Vaal01.png?scale=1&scaleIndex=0&w=1&h=1&v=3b21ce0cd4c0b9e8cf5db6257daf831a\",\"league\":\"Standard\",\"id\":\"57"
+   "5e571ccbea9ed070a1dd473794252a2ffe2aee6009e29050d6fad16c98a0af\",\"name\":\"\",\"typeLine\":\"Sacrifice at Midnight"
+   "\",\"identified\":true,\"descrText\":\"Can be used in the Templar Laboratory or a personal Map Device.\",\"flavourT"
+   "ext\":[\"Look to our Queen, for she will lead us into the light.\"],\"frameType\":0,\"category\":{\"maps\":[]},\"x"
+   "\":3,\"y\":3,\"inventoryId\":\"MainInventory\"}";
+
+const std::string kCategoriesItemWarMap =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":83,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Map"
+   "s\\/Atlas2Maps\\/New\\/SunkenCity.png?scale=1&scaleIndex=0&w=1&h=1&mn=1&mt=15&v=da5c60832e40b287dc576c7f806448ce\","
+   "\"league\":\"Standard\",\"id\":\"4ffac7327fa9ecf0996c9c7e456f9d53fbb2613f7bdbfd8f33faa2a36761355e\",\"name\":\"\","
+   "\"typeLine\":\"Sunken City Map\",\"identified\":true,\"properties\":[{\"name\":\"Map Tier\",\"values\":[[\"15\",0]]"
+   ",\"displayMode\":0,\"type\":1}],\"descrText\":\"Travel to this Map by using it in the Templar Laboratory or a perso"
+   "nal Map Device. Maps can only be used once.\",\"frameType\":0,\"category\":{\"maps\":[]},\"x\":9,\"y\":11,\"invento"
+   "ryId\":\"Stash2\"}";
+
+const std::string kCategoriesItemUniqueMap =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":74,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Map"
+   "s\\/HallOfGrandmasters.png?scale=1&scaleIndex=0&w=1&h=1&v=7b8e637fc9b6f7da6631cb8c48ce6af7\",\"league\":\"Standard"
+   "\",\"id\":\"006611ccbc68137c27db8ea1fd735af15ba5c1828691bf4ad1fde2e43e2f1883\",\"name\":\"Hall of Grandmasters\",\""
+   "typeLine\":\"Promenade Map\",\"identified\":true,\"properties\":[{\"name\":\"Map Tier\",\"values\":[[\"4\",0]],\"di"
+   "splayMode\":0,\"type\":1}],\"explicitMods\":[\"Contains the Immortalised Grandmasters\\nPvP damage scaling in effec"
+   "t\"],\"descrText\":\"Travel to this Map by using it in the Templar Laboratory or a personal Map Device. Maps can on"
+   "ly be used once.\",\"flavourText\":[\"The grandest and greatest ever to fight,\\r\",\"Divine the champions stand ta"
+   "ll.\\r\",\"But match their power, best their might,\\r\",\"And even the immortal may fall.\"],\"frameType\":3,\"cat"
+   "egory\":{\"maps\":[]},\"x\":5,\"y\":2,\"inventoryId\":\"MainInventory\"}";
+
+const std::string kCategoriesItemBreachstone =
+   "{\"verified\":false,\"w\":1,\"h\":1,\"ilvl\":0,\"icon\":\"https:\\/\\/web.poecdn.com\\/image\\/Art\\/2DItems\\/Curr"
+   "ency\\/Breach\\/BreachFragmentsLightning.png?scale=1&scaleIndex=0&w=1&h=1&v=01c1ec0220d90a59ebdbb1847a915710\",\"le"
+   "ague\":\"Standard\",\"id\":\"aeebf65ba96865632773520742e8e901b8d7c064e93de927fa57296e1659e749\",\"name\":\"\",\"typ"
+   "eLine\":\"Esh\'s Breachstone\",\"identified\":true,\"descrText\":\"Travel to Esh\'s Domain by using this item in th"
+   "e Templar Laboratory or a personal Map Device. Can only be used once.\",\"frameType\":0,\"category\":{\"maps\":[]},"
+   "\"x\":11,\"y\":1,\"inventoryId\":\"Stash58\"}";
+
 const std::string kSocketedItem =
    "{\"verified\":false,\"w\":2,\"h\":2,\"icon\":\"http://webcdn.pathofexile.com/image/Art/2DItems/Armours/Helmets/Helm"
    "etStrDex10.png?scale=1&w=2&h=2&v=0a540f285248cdb64d4607186e348e3d3\",\"support\":true,\"league\":\"Rampage\",\"sock"

--- a/test/testdata.h
+++ b/test/testdata.h
@@ -22,4 +22,15 @@
 #include <string>
 
 extern const std::string kItem1;
+extern const std::string kCategoriesItemCard;
+extern const std::string kCategoriesItemBelt;
+extern const std::string kCategoriesItemEssence;
+extern const std::string kCategoriesItemVaalGem;
+extern const std::string kCategoriesItemSupportGem;
+extern const std::string kCategoriesItemBow;
+extern const std::string kCategoriesItemClaw;
+extern const std::string kCategoriesItemFragment;
+extern const std::string kCategoriesItemWarMap;
+extern const std::string kCategoriesItemUniqueMap;
+extern const std::string kCategoriesItemBreachstone;
 extern const std::string kSocketedItem;

--- a/test/testitem.cpp
+++ b/test/testitem.cpp
@@ -42,3 +42,50 @@ void TestItem::Parse() {
     // This needs to match so that item hash migration is successful
     QCOMPARE(item.old_hash().c_str(), "36f0097563123e5296dc2eed54e9d6f3");
 }
+
+void TestItem::ParseCategories() {
+    rapidjson::Document doc;
+    doc.Parse(kCategoriesItemCard.c_str());
+    Item item(doc);
+    QCOMPARE(item.category().c_str(), "divination cards");
+
+    doc.Parse(kCategoriesItemBelt.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "belt");
+
+    doc.Parse(kCategoriesItemEssence.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "currency.essence");
+
+    doc.Parse(kCategoriesItemVaalGem.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "gems.skill.vaal");
+
+    doc.Parse(kCategoriesItemSupportGem.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "gems.support");
+
+    doc.Parse(kCategoriesItemBow.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "weapons.twohand.bow");
+
+    doc.Parse(kCategoriesItemClaw.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "weapons.onehand.claw");
+
+    doc.Parse(kCategoriesItemFragment.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "maps.misc");
+
+    doc.Parse(kCategoriesItemWarMap.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "maps.3.1.new");
+
+    doc.Parse(kCategoriesItemUniqueMap.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "maps.older uniques");
+
+    doc.Parse(kCategoriesItemBreachstone.c_str());
+    item = Item(doc);
+    QCOMPARE(item.category().c_str(), "currency.breach");
+}

--- a/test/testitem.h
+++ b/test/testitem.h
@@ -26,4 +26,5 @@ class TestItem : public QObject
     Q_OBJECT
 private slots:
     void Parse();
+    void ParseCategories();
 };


### PR DESCRIPTION
Disable PoB export button, so other changes can be accepted.
Reached feature parity with previous category approach.
Define an Item Wearable function, and use it to control PoB export button.
Remove old category name mappings.
Refactor around Item baseType, constants, function calls.
Don't draw a socket layer if there aren't any sockets.
Factor out some magic numbers. More intuitive painter image name.
Cleaner switch statements rather than recreate a small set of paths.
Add "Copy for Path of Building" button and grouping widget to UI.